### PR TITLE
💄 마커 타이틀 select-none + 기본 줌 레벨 17

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -73,7 +73,7 @@ function markerHtml(lot: ParkingLot, selected: boolean, hovered: boolean, showLa
   const isEasy = lot.curationTag === "easy";
 
   // 공통 스타일
-  const pillBase = "display:inline-flex;align-items:center;white-space:nowrap;cursor:pointer;";
+  const pillBase = "display:inline-flex;align-items:center;white-space:nowrap;cursor:pointer;user-select:none;-webkit-user-select:none;";
 
   if (selected) {
     const inner = showLabel

--- a/src/lib/geo-utils.ts
+++ b/src/lib/geo-utils.ts
@@ -20,7 +20,7 @@ function toRad(deg: number) {
 
 /** Default center: 서울 시청 */
 export const DEFAULT_CENTER = { lat: 37.5666, lng: 126.9784 }
-export const DEFAULT_ZOOM = Number(import.meta.env.VITE_DEFAULT_ZOOM) || 14
+export const DEFAULT_ZOOM = Number(import.meta.env.VITE_DEFAULT_ZOOM) || 17
 
 /** Difficulty score → 아이콘 (6단계) */
 export function getDifficultyIcon(score: number | null): string {


### PR DESCRIPTION
## Summary
- 마커 pill 텍스트 드래그 선택 방지 (`user-select: none`)
- 초기 줌 레벨 14 → 17로 변경 (주차장 라벨이 바로 보이도록)

## Test plan
- [ ] 지도 마커 텍스트를 드래그해도 선택되지 않는지 확인
- [ ] 초기 로딩 시 줌 레벨 17로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)