### PR TITLE
curation_tag 점수 분리 + 베이지안 C값 조정

### DIFF
--- a/scripts/compute-parking-stats.ts
+++ b/scripts/compute-parking-stats.ts
@@ -473,7 +473,7 @@ async function main() {
     }
   }
   if (easyLots.length > 0) {
-    const easyAbove35 = easyLots.filter((l) => l.finalScore > 3.5).length;
+    const easyAbove35 = easyLots.filter((l) => l.finalScore >= 3.5).length;
     const easyBelow20 = easyLots.filter((l) => l.finalScore <= 2.0).length;
     console.log(
       `[검증] Easy 태그(데이터 있음): ${easyLots.length}개 → 3.5 이상: ${easyAbove35}개, 2.0 이하: ${easyBelow20}개`,


### PR DESCRIPTION
## Summary
- `curation_tag`(hell/easy)가 `structural_prior`를 직접 앵커링하여 실제 크롤링 데이터와 무관하게 점수가 결정되던 문제 수정
- `computeStructuralPrior`에서 curation_tag → prior 매핑 제거 (태그는 크롤링 가이드 용도로만 유지)
- 베이지안 C값 5 → 1.5로 조정하여 실제 데이터 반영 속도 개선 (유저 리뷰 5건이면 극단 점수 도달 가능)
- 검증 로직을 `curationTag` 기반으로 변경 + 태그/점수 불일치 상세 로깅 추가

## 변경 전후 점수 분포
| 구간 | C=5 + 태그 앵커 (이전) | C=1.5 + 태그 분리 (이후) |
|------|----------------------|------------------------|
| 😊 초보추천 (4.0-5.0) | 7 | 3 |
| 🙂 무난 (3.3-3.9) | 231 | 1,450 |
| 😐 보통 (2.7-3.2) | 34,289 | 32,912 |
| 😕 별로 (2.0-2.6) | 2 | 243 |
| 💀 비추 (1.5-1.9) | 19 | 13 |
| 🔥 헬 (1.0-1.4) | 76 | 3 |

Closes #35

## Test plan
- [x] `compute-parking-stats.ts --remote` 실행하여 리모트 D1 점수 갱신 완료
- [x] 빌드 정상 확인
- [ ] 프로덕션에서 그랑서울 주차장 점수가 실제 데이터 기반으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)