### PR TITLE
🐛 fix: isMap 경로 판별 + panTo 보정 수정

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -187,7 +187,7 @@ export function MapView({
     if (mapRef.current && moveTo) {
       animatingRef.current = true;
       mapRef.current.setZoom(16);
-      const adjusted = getPanToAdjusted(mapRef.current, navermaps, moveTo, true);
+      const adjusted = getPanToAdjusted(mapRef.current, navermaps, moveTo, !!selectedLotId);
       mapRef.current.panTo(adjusted);
       setTimeout(() => { animatingRef.current = false; }, 800);
     }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -151,7 +151,7 @@ function RootComponent() {
   const lastMatch = matches[matches.length - 1];
   const active = lastMatch?.fullPath?.startsWith('/wiki') ? 'wiki' as const : 'map' as const;
   // 지도 페이지가 아니면 검색바/필터 없음 — 각 페이지에서 별도 처리
-  const isMap = active === 'map';
+  const isMap = lastMatch?.fullPath === '/';
 
   return (
     <>


### PR DESCRIPTION
## Summary
- PR #34 코드리뷰 반영
- `isMap`을 `active === 'map'` → `fullPath === '/'`로 변경하여 `/about`, `/settings` 등 신규 라우트에서 Header가 누락되지 않도록 수정
- `moveTo` panTo 시 `hasDetailPanel`을 `true` 하드코딩 → `!!selectedLotId`로 동적 판별하여 상세패널 미열림 시 불필요한 오프셋 방지

## Test plan
- [ ] `/wiki` 페이지에서 Header 정상 표시 확인
- [ ] `/` (지도) 페이지에서 Header 미표시 확인
- [ ] 검색 결과 클릭 시 지도 중심 보정이 자연스러운지 확인
- [ ] 마커 클릭 시 상세패널 열림 + 지도 중심 보정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)