### PR TITLE
🐛 fix: 모바일 마커 선택 시 하단 시트 가림 보정

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -19,9 +19,19 @@ function getPanToAdjusted(
   const proj = map.getProjection();
   const latLng = new navermaps.LatLng(coord.lat, coord.lng);
   const pixel = proj.fromCoordToOffset(latLng);
-  // 사이드바 280px 항상 + 상세패널 360px은 열려있을 때만
+
+  const isMobile = window.innerWidth < 768;
+  if (isMobile) {
+    // 모바일: 하단 시트(320px)가 마커를 가리므로 위쪽으로 보정
+    const bottomSheetOffset = hasDetailPanel ? 320 / 2 : 0;
+    return proj.fromOffsetToCoord(
+      new navermaps.Point(pixel.x, pixel.y + bottomSheetOffset)
+    );
+  }
+
+  // 데스크톱: 사이드바 280px 항상 + 상세패널 360px은 열려있을 때만
   const panelWidth = hasDetailPanel ? 280 + 360 : 280;
-  const panelOffset = window.innerWidth >= 768 ? panelWidth / 2 : 0;
+  const panelOffset = panelWidth / 2;
   return proj.fromOffsetToCoord(
     new navermaps.Point(pixel.x - panelOffset, pixel.y)
   );


### PR DESCRIPTION
## Summary
- 모바일에서 마커 선택 시 하단 시트(320px)가 마커를 가리는 문제 수정
- `getPanToAdjusted`에 모바일 분기 추가: y축 위쪽으로 160px 보정
- 데스크톱 기존 x축 보정 로직은 그대로 유지

## Test plan
- [x] 모바일(375x812) 뷰포트에서 마커 직접 클릭 → 마커가 하단 시트 위 가용 영역 중앙에 위치
- [x] 모바일 하단 리스트에서 항목 클릭 → 지도 이동 후 마커가 하단 시트에 가려지지 않음
- [x] 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)