### PR TITLE
refactor: 주차장 상세페이지(wiki) UI 매거진 스타일로 리뉴얼

### DIFF
--- a/src/routes/wiki/$slug.tsx
+++ b/src/routes/wiki/$slug.tsx
@@ -1,20 +1,7 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router'
-import {
-  BadgeCheck,
-  ChevronRight,
-  Clock,
-  CreditCard,
-  ExternalLink,
-  Flame,
-  Map as MapIcon,
-  MapPin,
-  ParkingSquare,
-  Phone,
-  Tag,
-  ThumbsUp,
-} from 'lucide-react'
+import { BadgeCheck, ChevronRight, ExternalLink, Map as MapIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { ParkingTabs } from '@/components/ParkingTabs'
-import { Badge } from '@/components/ui/badge'
 import { VoteBookmarkBar } from '@/components/VoteBookmarkBar'
 import { WikiMiniMap } from '@/components/WikiMiniMap'
 import {
@@ -111,9 +98,9 @@ export const Route = createFileRoute('/wiki/$slug')({
 
 function VerifiedBadge() {
   return (
-    <span className="inline-flex items-center gap-0.5 text-xs text-blue-600 font-medium">
-      <BadgeCheck className="size-3.5" />
-      검증됨
+    <span className="inline-flex items-center gap-0.5 text-[10px] text-stone-400">
+      <BadgeCheck className="size-3" />
+      검증
     </span>
   )
 }
@@ -128,50 +115,60 @@ const CATEGORY_META: Record<string, { icon: string; label: string }> = {
   etc: { icon: '📍', label: '기타' },
 }
 
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="text-[10px] font-semibold tracking-[0.15em] uppercase text-stone-400 mb-4">
+      {children}
+    </h2>
+  )
+}
+
 function NearbyPlacesSection({ places }: { places: NearbyPlaceInfo[] }) {
   if (places.length === 0) return null
 
   return (
-    <section className="bg-white rounded-xl border p-5 space-y-4">
-      <div className="space-y-1">
-        <div className="flex items-center gap-2">
-          <h2 className="font-semibold text-base">여기 주차하고 가볼 곳</h2>
-          <Badge variant="secondary" className="text-xs">
-            {places.length}곳
-          </Badge>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          자체 주차가 어려워 이 주차장을 이용하면 좋은 주변 장소
-        </p>
+    <section>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-[10px] font-semibold tracking-[0.15em] uppercase text-stone-400">
+          여기 주차하고 가볼 곳
+        </h2>
+        <span className="text-[11px] text-stone-400">{places.length}곳</span>
       </div>
+      <p className="text-xs text-stone-400 mb-4 mt-0.5">
+        자체 주차가 어려워 이 주차장을 이용하면 좋은 주변 장소
+      </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {places.map((place) => {
           const meta = CATEGORY_META[place.category] ?? CATEGORY_META.etc
           return (
             <div
               key={place.id}
-              className="flex items-start gap-3 rounded-lg border p-3 hover:bg-gray-50 transition-colors overflow-hidden"
+              className="flex items-start gap-3 bg-white rounded-2xl p-3.5 shadow-[0_1px_4px_rgba(0,0,0,0.06)]"
             >
               {place.thumbnailUrl ? (
                 <img
                   src={place.thumbnailUrl}
                   alt={place.name}
-                  className="size-14 rounded-lg object-cover shrink-0"
+                  className="size-14 rounded-xl object-cover shrink-0"
                   loading="lazy"
                 />
               ) : (
-                <span className="size-14 rounded-lg bg-gray-100 flex items-center justify-center text-xl shrink-0">
+                <span className="size-14 rounded-xl bg-stone-100 flex items-center justify-center text-xl shrink-0">
                   {meta.icon}
                 </span>
               )}
               <div className="min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <span className="font-medium text-sm truncate">{place.name}</span>
-                  <span className="text-xs text-muted-foreground shrink-0">{meta.label}</span>
+                <div className="flex items-baseline gap-1.5">
+                  <span className="font-semibold text-sm text-stone-900 truncate">
+                    {place.name}
+                  </span>
+                  <span className="text-[11px] text-stone-400 shrink-0">{meta.label}</span>
                 </div>
-                {place.tip && <p className="text-xs text-muted-foreground mt-0.5">{place.tip}</p>}
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {place.mentionCount}개 블로그에서 언급
+                {place.tip && (
+                  <p className="text-xs text-stone-500 mt-0.5 leading-relaxed">{place.tip}</p>
+                )}
+                <p className="text-[10px] text-stone-400 mt-1">
+                  {place.mentionCount}개 블로그 언급
                 </p>
               </div>
             </div>
@@ -188,73 +185,86 @@ function WikiDetailPage() {
   const icon = getDifficultyIcon(lot.difficulty.score)
   const label = getDifficultyLabel(lot.difficulty.score)
   const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
+  const isWarnLevel = lot.difficulty.score !== null && lot.difficulty.score < 2.0
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-[#f9f8f5]">
       {/* 브레드크럼 */}
-      <div className="bg-white border-b">
-        <div className="max-w-3xl mx-auto px-4 py-2 text-xs text-muted-foreground flex items-center gap-1">
-          <Link to="/" className="hover:text-foreground transition-colors">
+      <div className="bg-white/80 backdrop-blur-sm border-b border-stone-200">
+        <div className="max-w-3xl mx-auto px-4 py-2 text-[11px] text-stone-400 flex items-center gap-1.5">
+          <Link to="/" className="hover:text-stone-700 transition-colors">
             지도
           </Link>
-          <ChevronRight className="size-3" />
-          <Link to="/wiki" className="hover:text-foreground transition-colors">
+          <ChevronRight className="size-2.5" />
+          <Link to="/wiki" className="hover:text-stone-700 transition-colors">
             둘러보기
           </Link>
-          <ChevronRight className="size-3" />
-          <span className="text-foreground truncate">{lot.name}</span>
+          <ChevronRight className="size-2.5" />
+          <span className="text-stone-600 truncate">{lot.name}</span>
         </div>
       </div>
 
-      <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
+      <div className="max-w-3xl mx-auto px-4">
         {/* 헤더 */}
-        <header className="space-y-3">
-          <div className="flex items-start gap-3">
-            <div
-              className={`size-4 rounded-full shrink-0 mt-1.5 ${getDifficultyColor(lot.difficulty.score)}`}
-            />
-            <h1 className="text-2xl font-bold leading-tight">{lot.name}</h1>
-          </div>
+        <header className="py-8 border-b border-stone-200">
+          <div className="flex items-start justify-between gap-6">
+            {/* 타이틀 + 주소 */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-2">
+                <div
+                  className={`size-2.5 rounded-full shrink-0 ${getDifficultyColor(lot.difficulty.score)}`}
+                />
+                {lot.type && (
+                  <span className="text-[11px] text-stone-400 font-medium">{lot.type}</span>
+                )}
+              </div>
+              <h1 className="text-2xl sm:text-3xl font-bold text-stone-900 leading-tight mb-2">
+                {lot.name}
+              </h1>
+              <p className="text-sm text-stone-500 leading-relaxed">{lot.address}</p>
+              {lot.poiTags && lot.poiTags.length > 0 && (
+                <div className="flex gap-1.5 mt-3 flex-wrap">
+                  {lot.poiTags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-[11px] text-stone-500 bg-stone-100 px-2.5 py-0.5 rounded-full"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
 
-          {/* 배지 */}
-          <div className="flex items-center gap-2 flex-wrap">
-            {lot.difficulty.score !== null && lot.difficulty.score < 2.0 && (
-              <Badge variant="destructive" className="text-xs gap-1">
-                <Flame className="size-3" />
-                초보 주의
-              </Badge>
-            )}
-            {lot.difficulty.score !== null && lot.difficulty.score >= 4.0 && (
-              <Badge className="text-xs gap-1 bg-green-500 hover:bg-green-600">
-                <ThumbsUp className="size-3" />
-                초보 추천
-              </Badge>
-            )}
-            <Badge variant="secondary" className="text-sm">
-              {icon} {label}
-            </Badge>
-            {reliabilityBadge && (
-              <Badge variant="outline" className={`text-xs ${reliabilityBadge.className}`}>
-                {reliabilityBadge.label}
-              </Badge>
-            )}
-            <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>
-              {lot.pricing.isFree ? '무료' : '유료'}
-            </Badge>
-            {lot.type && (
-              <Badge variant="outline" className="text-xs">
-                {lot.type}
-              </Badge>
-            )}
+            {/* 난이도 평점 블록 */}
+            <div className="shrink-0 bg-stone-50 rounded-2xl px-4 py-3.5 text-center min-w-[72px]">
+              <div className="text-4xl leading-none mb-1.5">{icon}</div>
+              <div className="text-[11px] font-semibold text-stone-600 mb-0.5">{label}</div>
+              {lot.difficulty.score !== null ? (
+                <div className="text-xl font-bold text-stone-900 tabular-nums leading-none">
+                  {lot.difficulty.score.toFixed(1)}
+                </div>
+              ) : (
+                <div className="text-xs text-stone-400">—</div>
+              )}
+              {lot.difficulty.reviewCount > 0 && (
+                <div className="text-[10px] text-stone-400 mt-1">
+                  {lot.difficulty.reviewCount}개 리뷰
+                </div>
+              )}
+              {reliabilityBadge && (
+                <div className="text-[10px] text-stone-400 mt-0.5">{reliabilityBadge.label}</div>
+              )}
+            </div>
           </div>
 
           {/* 액션 바 */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 mt-6">
             <a
               href={`https://map.naver.com/v5/directions/-/${lot.lng},${lot.lat},${encodeURIComponent(lot.name)}/-/transit?c=${lot.lng},${lot.lat},15,0,0,0,dh`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-lg bg-green-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-600 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full bg-stone-900 px-4 py-1.5 text-xs font-medium text-white hover:bg-stone-700 transition-colors"
             >
               <ExternalLink className="size-3" />
               길찾기
@@ -262,7 +272,7 @@ function WikiDetailPage() {
             <Link
               to="/"
               search={{ lotId: lot.id }}
-              className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-gray-100 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full border border-stone-300 px-4 py-1.5 text-xs font-medium text-stone-700 hover:bg-stone-50 transition-colors"
             >
               <MapIcon className="size-3" />
               지도에서 보기
@@ -271,124 +281,137 @@ function WikiDetailPage() {
           </div>
         </header>
 
-        {/* 큐레이션 사유 */}
-        {lot.curationReason && (
-          <div
-            className={`text-sm rounded-lg px-4 py-3 ${
-              lot.difficulty.score !== null && lot.difficulty.score < 2.0
-                ? 'bg-red-50 text-red-700'
-                : 'bg-green-50 text-green-700'
-            }`}
-          >
-            {lot.difficulty.score !== null && lot.difficulty.score < 2.0 ? '⚠️' : '✅'}{' '}
-            {lot.curationReason}
-            {lot.featuredSource === '1010' && (
-              <span className="block mt-1 text-xs opacity-75">
-                📺 10시10분 유튜브에 소개된 주차장
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* 기본 정보 카드 */}
-        <section className="bg-white rounded-xl border p-5 space-y-4">
-          <h2 className="font-semibold text-base">기본 정보</h2>
-
-          <div className="grid gap-3">
-            <div className="flex items-start gap-2.5 text-sm">
-              <MapPin className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-              <span>{lot.address}</span>
-            </div>
-
-            <div className="flex items-start gap-2.5 text-sm">
-              <Clock className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-              <div>
-                <div className="flex items-center gap-1.5">
-                  평일 {lot.operatingHours.weekday.start}-{lot.operatingHours.weekday.end}
-                  {lot.verifiedSource && <VerifiedBadge />}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  토 {lot.operatingHours.saturday.start}-{lot.operatingHours.saturday.end} · 공휴일{' '}
-                  {lot.operatingHours.holiday.start}-{lot.operatingHours.holiday.end}
-                </div>
-              </div>
-            </div>
-
-            {!lot.pricing.isFree && (
-              <div className="flex items-start gap-2.5 text-sm">
-                <CreditCard className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-                <div>
-                  <div className="flex items-center gap-1.5">
-                    기본 {lot.pricing.baseTime}분 {lot.pricing.baseFee.toLocaleString()}원
-                    {lot.verifiedSource && <VerifiedBadge />}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    추가 {lot.pricing.extraTime}분당 {lot.pricing.extraFee.toLocaleString()}원
-                    {lot.pricing.dailyMax &&
-                      ` · 1일 최대 ${lot.pricing.dailyMax.toLocaleString()}원`}
-                    {lot.pricing.monthlyPass &&
-                      ` · 월정기 ${lot.pricing.monthlyPass.toLocaleString()}원`}
-                  </div>
-                </div>
-              </div>
-            )}
-            {lot.pricing.isFree && (
-              <div className="flex items-center gap-2.5 text-sm">
-                <CreditCard className="size-4 shrink-0 text-muted-foreground" />
-                <span className="text-green-600 font-medium flex items-center gap-1.5">
-                  무료 주차장
-                  {lot.verifiedSource && <VerifiedBadge />}
-                </span>
-              </div>
-            )}
-
-            {lot.totalSpaces > 0 && (
-              <div className="flex items-center gap-2.5 text-sm">
-                <ParkingSquare className="size-4 shrink-0 text-muted-foreground" />
-                <span>총 {lot.totalSpaces}면</span>
-              </div>
-            )}
-
-            {lot.phone && (
-              <div className="flex items-center gap-2.5 text-sm">
-                <Phone className="size-4 shrink-0 text-muted-foreground" />
-                <a href={`tel:${lot.phone}`} className="text-blue-500 underline">
-                  {lot.phone}
-                </a>
-              </div>
-            )}
-
-            {lot.poiTags && lot.poiTags.length > 0 && (
-              <div className="flex items-start gap-2.5 text-sm">
-                <Tag className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-                <div className="flex flex-wrap gap-1.5">
-                  {lot.poiTags.map((tag) => (
-                    <Badge key={tag} variant="outline" className="text-xs">
-                      {tag}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {lot.notes && (
-              <p className="text-xs text-muted-foreground bg-gray-50 rounded-lg px-3 py-2">
-                {lot.notes}
+        <div className="py-8 space-y-10">
+          {/* 큐레이션 사유 */}
+          {lot.curationReason && (
+            <div
+              className={`border-l-[3px] pl-4 ${isWarnLevel ? 'border-red-400' : 'border-emerald-500'}`}
+            >
+              <p
+                className={`text-sm leading-relaxed ${isWarnLevel ? 'text-red-700' : 'text-stone-700'}`}
+              >
+                {isWarnLevel ? '⚠️' : '✅'} {lot.curationReason}
               </p>
-            )}
-          </div>
-        </section>
+              {lot.featuredSource === '1010' && (
+                <p className="text-xs text-stone-400 mt-1.5">📺 10시10분 유튜브에 소개된 주차장</p>
+              )}
+            </div>
+          )}
 
-        {/* 미니 지도 */}
-        <WikiMiniMap lat={lot.lat} lng={lot.lng} name={lot.name} />
+          {/* 기본 정보 */}
+          <section>
+            <SectionLabel>기본 정보</SectionLabel>
+            <div className="bg-white rounded-2xl shadow-[0_1px_4px_rgba(0,0,0,0.06)] overflow-hidden">
+              <dl className="divide-y divide-stone-100">
+                {/* 위치 */}
+                <div className="flex gap-4 px-5 py-3.5">
+                  <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">위치</dt>
+                  <dd className="text-sm text-stone-800 leading-relaxed">{lot.address}</dd>
+                </div>
 
-        {/* 주변 갈만한 곳 */}
-        <NearbyPlacesSection places={nearbyPlaces} />
+                {/* 운영시간 */}
+                <div className="flex gap-4 px-5 py-3.5">
+                  <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">운영</dt>
+                  <dd className="text-sm text-stone-800 space-y-0.5">
+                    <div className="flex items-center gap-1.5">
+                      <span>
+                        평일 {lot.operatingHours.weekday.start}–{lot.operatingHours.weekday.end}
+                      </span>
+                      {lot.verifiedSource && <VerifiedBadge />}
+                    </div>
+                    <div className="text-xs text-stone-500">
+                      토 {lot.operatingHours.saturday.start}–{lot.operatingHours.saturday.end} ·
+                      공휴일 {lot.operatingHours.holiday.start}–{lot.operatingHours.holiday.end}
+                    </div>
+                  </dd>
+                </div>
 
-        {/* 리뷰/블로그/영상 탭 */}
-        <section className="bg-white rounded-xl border p-5">
-          <ParkingTabs lotId={lot.id} expanded />
-        </section>
+                {/* 요금 */}
+                <div className="flex gap-4 px-5 py-3.5">
+                  <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">요금</dt>
+                  <dd className="text-sm text-stone-800 space-y-0.5">
+                    {lot.pricing.isFree ? (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-emerald-700 font-medium">무료</span>
+                        {lot.verifiedSource && <VerifiedBadge />}
+                      </div>
+                    ) : (
+                      <>
+                        <div className="flex items-center gap-1.5">
+                          기본 {lot.pricing.baseTime}분 {lot.pricing.baseFee.toLocaleString()}원
+                          {lot.verifiedSource && <VerifiedBadge />}
+                        </div>
+                        <div className="text-xs text-stone-500">
+                          추가 {lot.pricing.extraTime}분당 {lot.pricing.extraFee.toLocaleString()}원
+                          {lot.pricing.dailyMax &&
+                            ` · 1일 최대 ${lot.pricing.dailyMax.toLocaleString()}원`}
+                          {lot.pricing.monthlyPass &&
+                            ` · 월정기 ${lot.pricing.monthlyPass.toLocaleString()}원`}
+                        </div>
+                      </>
+                    )}
+                  </dd>
+                </div>
+
+                {/* 규모 */}
+                {lot.totalSpaces > 0 && (
+                  <div className="flex gap-4 px-5 py-3.5">
+                    <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">
+                      규모
+                    </dt>
+                    <dd className="text-sm text-stone-800">총 {lot.totalSpaces}면</dd>
+                  </div>
+                )}
+
+                {/* 전화 */}
+                {lot.phone && (
+                  <div className="flex gap-4 px-5 py-3.5">
+                    <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">
+                      전화
+                    </dt>
+                    <dd className="text-sm">
+                      <a
+                        href={`tel:${lot.phone}`}
+                        className="text-stone-800 underline underline-offset-2 hover:text-stone-500 transition-colors"
+                      >
+                        {lot.phone}
+                      </a>
+                    </dd>
+                  </div>
+                )}
+
+                {/* 특기사항 */}
+                {lot.notes && (
+                  <div className="flex gap-4 px-5 py-3.5">
+                    <dt className="text-xs font-medium text-stone-400 w-14 shrink-0 pt-0.5">
+                      비고
+                    </dt>
+                    <dd className="text-xs text-stone-500 leading-relaxed">{lot.notes}</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          </section>
+
+          {/* 위치 지도 */}
+          <section>
+            <SectionLabel>위치</SectionLabel>
+            <div className="rounded-2xl overflow-hidden shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
+              <WikiMiniMap lat={lot.lat} lng={lot.lng} name={lot.name} />
+            </div>
+          </section>
+
+          {/* 주변 갈만한 곳 */}
+          {nearbyPlaces.length > 0 && <NearbyPlacesSection places={nearbyPlaces} />}
+
+          {/* 리뷰 / 영상 / 웹사이트 */}
+          <section>
+            <SectionLabel>커뮤니티</SectionLabel>
+            <div className="bg-white rounded-2xl shadow-[0_1px_4px_rgba(0,0,0,0.06)] p-5">
+              <ParkingTabs lotId={lot.id} expanded />
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- 배경을 warm off-white(#f9f8f5)로 변경, 테두리 대신 미세 그림자 카드
- 섹션 헤더: uppercase + letter-spacing으로 에디토리얼 레이블 스타일
- 난이도: 헤더 우측 평점 블록(이모지 4xl + 점수 + 리뷰수)으로 강조
- 기본정보: 아이콘 리스트 → dl/dt/dd 테이블 (위치/운영/요금/규모)
- 큐레이션 사유: 배경 박스 → border-l 풀쿼트 스타일
- 버튼: pill(rounded-full) + stone-900 다크 프라이머리
- 뱃지 과다 사용 제거, ParkingTabs 화이트 카드로 감싸 스타일 충돌 방지