### PR TITLE
🔧 Claude Code Review 자동 트리거 정지

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,16 +1,11 @@
 name: Claude Code Review
 
+# 자동 트리거 정지 (API 키 미사용). 필요 시 Actions 탭에서 수동 실행.
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   claude-review:
-    if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- API 키를 더 이상 쓰지 않게 되어 PR마다 실패하던 `claude-code-review.yml` 자동 트리거 비활성화
- `workflow_dispatch`만 남겨 필요 시 GitHub Actions 탭에서 수동 실행 가능
- `claude.yml`은 @claude 멘션 시에만 동작하므로 유지

## Test plan

- [ ] PR 생성 시 Claude Code Review 워크플로우가 자동 실행되지 않는지 확인
- [ ] Actions 탭에서 'Claude Code Review' 워크플로우가 manual run 옵션을 노출하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)