### PR TITLE
✨ 지도 상세 패널 UI 위키 톤 통일 + 모바일 시트 스냅 개선 (#82)

### DIFF
--- a/src/components/ParkingCard.tsx
+++ b/src/components/ParkingCard.tsx
@@ -1,10 +1,12 @@
 import { Link } from '@tanstack/react-router'
 import {
+  ChevronRight,
   Clock,
   CreditCard,
-  ExternalLink,
   Flame,
   MapPin,
+  MessageSquare,
+  ParkingSquare,
   Phone,
   Star,
   Tag,
@@ -23,8 +25,20 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { VoteBookmarkBar } from '@/components/VoteBookmarkBar'
-import { getDifficultyColor, getDistance } from '@/lib/geo-utils'
+import {
+  getDifficultyColor,
+  getDifficultyLabel,
+  getDistance,
+  getReliabilityBadge,
+} from '@/lib/geo-utils'
+import {
+  formatOperatingHours,
+  formatPhone,
+  formatPricing,
+  formatTotalSpaces,
+} from '@/lib/parking-display'
 import { makeParkingSlug } from '@/lib/slug'
+import { fetchTabCounts } from '@/server/parking'
 import type { ParkingLot } from '@/types/parking'
 
 const COLLAPSED_HEIGHT = 320
@@ -50,6 +64,12 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
   const dragStartY = useRef(0)
   const dragStartHeight = useRef(COLLAPSED_HEIGHT)
   const lastDragDelta = useRef(0)
+
+  const [tabCounts, setTabCounts] = useState<{ reviews: number; blog: number; media: number }>({
+    reviews: 0,
+    blog: 0,
+    media: 0,
+  })
 
   const getExpandedHeight = useCallback(
     () => Math.max(COLLAPSED_HEIGHT, Math.round(window.innerHeight * EXPANDED_HEIGHT_RATIO)),
@@ -91,6 +111,21 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     }
   }, [lot])
 
+  // 평판 카운트 fetch
+  useEffect(() => {
+    if (!lot) return
+    let cancelled = false
+    setTabCounts({ reviews: 0, blog: 0, media: 0 })
+    fetchTabCounts({ data: { parkingLotId: lot.id } })
+      .then((counts) => {
+        if (!cancelled) setTabCounts(counts)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [lot])
+
   // 아래로 스크롤 → 확장
   const lastScrollTop = useRef(0)
   const handleScroll = useCallback(() => {
@@ -126,7 +161,7 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
   }, [getExpandedHeight, isMobile])
 
   const handleDragStart = useCallback(
-    (e: React.TouchEvent<HTMLButtonElement>) => {
+    (e: React.TouchEvent<HTMLElement>) => {
       dragStartY.current = e.touches[0].clientY
       dragStartHeight.current = sheetHeight
       lastDragDelta.current = 0
@@ -136,7 +171,7 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
   )
 
   const handleDragMove = useCallback(
-    (e: React.TouchEvent<HTMLButtonElement>) => {
+    (e: React.TouchEvent<HTMLElement>) => {
       if (!isDragging) return
 
       const deltaY = e.touches[0].clientY - dragStartY.current
@@ -188,6 +223,18 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
 
   if (!lot || !isMobile) return null
 
+  const score = lot.difficulty.score
+  const scoreLabel = getDifficultyLabel(score)
+  const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
+  const summary = lot.curationReason ?? lot.aiSummary
+  const operatingHours = formatOperatingHours(lot.operatingHours)
+  const pricing = formatPricing(lot.pricing)
+  const totalSpacesLabel = formatTotalSpaces(lot.totalSpaces)
+  const phoneLabel = formatPhone(lot.phone)
+  const slug = makeParkingSlug(lot.name, lot.id)
+  const hasAiTips = Boolean(lot.aiTipPricing || lot.aiTipVisit || lot.aiTipAlternative)
+  const hasContentAbove = Boolean(summary) || hasAiTips
+  const sourceCount = tabCounts.reviews + tabCounts.blog + tabCounts.media
   const distance =
     userLocated && userLat && userLng ? getDistance(userLat, userLng, lot.lat, lot.lng) : null
 
@@ -209,7 +256,7 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
           onScroll={handleScroll}
           className="flex-1 overflow-y-auto overscroll-contain"
         >
-          {/* 드래그 핸들 + 타이틀 — sticky 고정 */}
+          {/* 드래그 핸들 + 닫기 — sticky 고정 */}
           <div className="sticky top-0 z-10 bg-background">
             <div className="flex items-center justify-between px-4 pt-1.5">
               <div className="w-8" />
@@ -231,185 +278,245 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
               </button>
             </div>
 
-            <SheetHeader className="[&]:p-0 [&]:px-4 [&]:pb-2">
-              <SheetTitle className="text-lg font-bold mb-2 flex items-center gap-2">
-                <div
-                  className={`size-2.5 rounded-full shrink-0 ${getDifficultyColor(lot.difficulty.score)}`}
-                />
-                {lot.name}
-              </SheetTitle>
-              {/* 헤더 한 줄: 별점 + 거리 + 주차가능 배지 */}
-              <div className="flex items-center gap-2 flex-wrap text-xs">
-                <div className="flex items-center gap-1">
-                  <div className="flex items-center gap-0.5">
-                    {[1, 2, 3, 4, 5].map((i) => {
-                      const rating = lot.difficulty.score ?? 0
-                      return (
-                        <Star
-                          key={i}
-                          className={`size-3 ${
-                            i <= Math.round(rating)
-                              ? 'fill-yellow-400 text-yellow-400'
-                              : 'text-gray-300'
-                          }`}
-                        />
-                      )
-                    })}
-                  </div>
-                  <span className="font-semibold">{(lot.difficulty.score ?? 0).toFixed(1)}</span>
-                </div>
-                {distance !== null && (
-                  <span className="text-muted-foreground">
-                    {distance < 1 ? `${Math.round(distance * 1000)}m` : `${distance.toFixed(1)}km`}
-                  </span>
-                )}
-                <Badge className="bg-green-500 hover:bg-green-600 text-white">주차 가능</Badge>
-              </div>
+            <SheetHeader className="[&]:p-0 [&]:px-4 [&]:pb-2 [&]:pt-1">
+              <SheetTitle className="sr-only">{lot.name}</SheetTitle>
               <SheetDescription className="sr-only">주차장 상세 정보</SheetDescription>
             </SheetHeader>
           </div>
 
-          <div className="px-4 pb-4 space-y-3">
-            {/* AI Summary */}
-            {lot.curationReason && (
-              <div
-                className={`rounded-lg px-3 py-2.5 text-xs space-y-1 ${
-                  lot.difficulty.score !== null && lot.difficulty.score < 2.0
-                    ? 'bg-red-50 border border-red-200'
-                    : 'bg-blue-50 border border-blue-200'
-                }`}
-              >
-                <div className="font-semibold flex items-center gap-1">
-                  {lot.difficulty.score !== null && lot.difficulty.score < 2.0 ? '⚠️' : '✨'} 요약
-                </div>
-                <p
-                  className={
-                    lot.difficulty.score !== null && lot.difficulty.score < 2.0
-                      ? 'text-red-700'
-                      : 'text-blue-700'
-                  }
-                >
-                  {lot.curationReason}
-                </p>
+          <div className="px-4 pb-6 space-y-4">
+            {/* 헤더: 뱃지 + 제목 + 주소 */}
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>
+                  {lot.pricing.isFree ? '무료' : '유료'}
+                </Badge>
+                <Badge variant="outline">{lot.type}</Badge>
+                {score !== null && score >= 4.0 && (
+                  <Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100">
+                    <ThumbsUp className="size-3" />
+                    초보 추천
+                  </Badge>
+                )}
+                {score !== null && score < 2.0 && (
+                  <Badge variant="destructive" className="gap-1">
+                    <Flame className="size-3" />
+                    초보 주의
+                  </Badge>
+                )}
               </div>
-            )}
-
-            {/* 배지 섹션 */}
-            <div className="flex items-center gap-2 flex-wrap text-xs">
-              <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>
-                {lot.pricing.isFree ? '무료' : '유료'}
-              </Badge>
-              {lot.difficulty.reviewCount > 0 && (
-                <span className="text-muted-foreground">리뷰 {lot.difficulty.reviewCount}개</span>
-              )}
-              {lot.difficulty.score !== null && lot.difficulty.score < 2.0 && (
-                <Badge variant="destructive" className="gap-1 ml-auto">
-                  <Flame className="size-3" />
-                  초보 주의
-                </Badge>
-              )}
-              {lot.difficulty.score !== null && lot.difficulty.score >= 4.0 && (
-                <Badge className="gap-1 bg-green-500 hover:bg-green-600">
-                  <ThumbsUp className="size-3" />
-                  초보 추천
-                </Badge>
-              )}
+              <h2 className="text-xl font-bold leading-tight tracking-normal flex items-center gap-2">
+                <span
+                  className={`size-2.5 rounded-full shrink-0 ${getDifficultyColor(score)}`}
+                  aria-hidden="true"
+                />
+                {lot.name}
+              </h2>
+              <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                <MapPin className="mt-0.5 size-4 shrink-0" />
+                <span>{lot.address}</span>
+                {distance !== null && (
+                  <span className="ml-auto shrink-0 tabular-nums">
+                    {distance < 1 ? `${Math.round(distance * 1000)}m` : `${distance.toFixed(1)}km`}
+                  </span>
+                )}
+              </div>
             </div>
 
-            {/* 액션 버튼 영역 */}
-            <div className="flex gap-2">
-              <div className="flex-1">
-                <NavigationButton
-                  lat={lot.lat}
-                  lng={lot.lng}
-                  name={lot.name}
-                  buttonClassName="w-full justify-center py-2 text-sm"
-                />
+            {/* 점수 + 평판 근거 2-카드 그리드 */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg border bg-white p-3">
+                <div className="text-xs font-medium text-muted-foreground">쉬움 점수</div>
+                <div className="mt-2 flex items-end gap-2">
+                  <span className="text-3xl font-black leading-none">
+                    {score === null ? '-' : score.toFixed(1)}
+                  </span>
+                  <span className="pb-1 text-sm font-semibold text-muted-foreground">/ 5</span>
+                </div>
+                <div className="mt-2 flex items-center gap-1.5 text-sm font-medium">
+                  <div className="flex items-center gap-0.5">
+                    {[1, 2, 3, 4, 5].map((i) => (
+                      <Star
+                        key={i}
+                        className={`size-3 ${
+                          i <= Math.round(score ?? 0)
+                            ? 'fill-yellow-400 text-yellow-400'
+                            : 'text-gray-300'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <span>{scoreLabel}</span>
+                </div>
               </div>
+
+              <div className="rounded-lg border bg-white p-3">
+                <div className="text-xs font-medium text-muted-foreground">평판 근거</div>
+                <div className="mt-2 text-3xl font-black leading-none">{sourceCount}</div>
+                <div className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <MessageSquare className="size-3.5" />
+                  리뷰/영상/웹 글
+                </div>
+              </div>
+            </div>
+
+            {/* 액션 행 */}
+            <div className="flex flex-wrap items-center gap-2">
+              <NavigationButton
+                lat={lot.lat}
+                lng={lot.lng}
+                name={lot.name}
+                buttonClassName="px-3 py-2 text-sm"
+              />
+              <VoteBookmarkBar lotId={lot.id} />
+              {lot.phone && (
+                <a
+                  href={`tel:${lot.phone}`}
+                  className="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors hover:bg-zinc-50"
+                >
+                  <Phone className="size-3.5" />
+                  전화
+                </a>
+              )}
               <Link
                 to="/wiki/$slug"
-                params={{ slug: makeParkingSlug(lot.name, lot.id) }}
+                params={{ slug }}
                 onClick={handleClose}
-                className="shrink-0 flex items-center gap-1 rounded-lg border border-border px-3 py-2 text-xs text-muted-foreground hover:bg-gray-50 transition-colors"
+                className="ml-auto inline-flex items-center gap-1 px-2.5 py-2 text-sm font-medium rounded-lg border hover:bg-gray-50 transition-colors"
               >
-                <ExternalLink className="size-3.5" />
                 자세히보기
+                <ChevronRight className="size-3" />
               </Link>
             </div>
 
-            {/* 투표 바 */}
-            <VoteBookmarkBar lotId={lot.id} />
+            {reliabilityBadge && (
+              <Badge variant="outline" className={reliabilityBadge.className}>
+                {reliabilityBadge.label}
+              </Badge>
+            )}
 
-            {/* 주소 */}
-            <div className="flex items-start gap-2">
-              <MapPin className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-              <span className="text-sm">{lot.address}</span>
-            </div>
+            {/* AI 요약 — 위키 톤 (분기 제거, 항상 파란 카드) */}
+            {summary && (
+              <section className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+                <div className="mb-2 text-xs font-semibold text-blue-700">AI 요약</div>
+                <p className="whitespace-pre-line text-sm font-medium leading-relaxed text-zinc-900">
+                  {summary}
+                </p>
+                {lot.featuredSource === '1010' && (
+                  <p className="mt-3 pt-2 border-t border-blue-200 text-xs text-blue-700/80">
+                    📺 10시10분 유튜브 채널에 소개된 주차장
+                  </p>
+                )}
+              </section>
+            )}
 
-            {/* 운영시간 */}
-            <div className="flex items-start gap-2">
-              <Clock className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-              <div>
-                <div className="text-sm font-medium">
-                  평일 {lot.operatingHours.weekday.start}-{lot.operatingHours.weekday.end}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  토 {lot.operatingHours.saturday.start}-{lot.operatingHours.saturday.end} · 공휴일{' '}
-                  {lot.operatingHours.holiday.start}-{lot.operatingHours.holiday.end}
-                </div>
-              </div>
-            </div>
-
-            {/* 요금 */}
-            {!lot.pricing.isFree && (
-              <div className="flex items-start gap-2">
-                <CreditCard className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-                <div>
-                  <div className="text-sm font-medium">
-                    기본 {lot.pricing.baseTime}분 {lot.pricing.baseFee.toLocaleString()}원
+            {/* AI 팁 3-카드 그리드 (모바일은 1열로 떨어짐) */}
+            {hasAiTips && (
+              <section className="grid grid-cols-1 gap-2">
+                {lot.aiTipPricing && (
+                  <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                    <span className="mb-1 block text-sm font-semibold text-gray-900">요금</span>
+                    {lot.aiTipPricing}
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    추가 {lot.pricing.extraTime}분당 {lot.pricing.extraFee.toLocaleString()}원
-                    {lot.pricing.dailyMax &&
-                      ` · 1일 최대 ${lot.pricing.dailyMax.toLocaleString()}원`}
+                )}
+                {lot.aiTipVisit && (
+                  <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                    <span className="mb-1 block text-sm font-semibold text-gray-900">방문 팁</span>
+                    {lot.aiTipVisit}
+                  </div>
+                )}
+                {lot.aiTipAlternative && (
+                  <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                    <span className="mb-1 block text-sm font-semibold text-gray-900">대안</span>
+                    {lot.aiTipAlternative}
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* 기본 정보 */}
+            <section
+              className={hasContentAbove ? 'border-t-2 border-zinc-300 pt-6 pb-2' : 'pt-1 pb-2'}
+            >
+              <h3 className="mb-3 text-base font-bold">주차장 정보</h3>
+              <div className="space-y-3 text-sm">
+                <div className="flex items-start gap-2.5">
+                  <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <span>{lot.address}</span>
+                </div>
+
+                <div className="flex items-start gap-2.5">
+                  <Clock className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div>
+                    <div className={operatingHours.isUnknown ? 'text-muted-foreground' : ''}>
+                      {operatingHours.primary}
+                    </div>
+                    {operatingHours.secondary && (
+                      <div className="text-xs text-muted-foreground">
+                        {operatingHours.secondary}
+                      </div>
+                    )}
                   </div>
                 </div>
-              </div>
-            )}
 
-            {/* 전화번호 */}
-            {lot.phone && (
-              <div className="flex items-center gap-2">
-                <Phone className="size-4 shrink-0 text-muted-foreground" />
-                <a href={`tel:${lot.phone}`} className="text-sm text-blue-500 underline">
-                  {lot.phone}
-                </a>
-              </div>
-            )}
-
-            {/* POI 태그 */}
-            {lot.poiTags && lot.poiTags.length > 0 && (
-              <div className="flex items-start gap-2">
-                <Tag className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-                <div className="flex flex-wrap gap-1.5">
-                  {lot.poiTags.map((tag) => (
-                    <Badge key={tag} variant="outline" className="text-xs">
-                      {tag}
-                    </Badge>
-                  ))}
+                <div className="flex items-start gap-2.5">
+                  <CreditCard className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div>
+                    <div className={pricing.isUnknown ? 'text-muted-foreground' : ''}>
+                      {pricing.primary}
+                    </div>
+                    {pricing.secondary && (
+                      <div className="text-xs text-muted-foreground">{pricing.secondary}</div>
+                    )}
+                  </div>
                 </div>
+
+                {totalSpacesLabel && (
+                  <div className="flex items-center gap-2.5">
+                    <ParkingSquare className="size-4 shrink-0 text-muted-foreground" />
+                    <span>{totalSpacesLabel}</span>
+                  </div>
+                )}
+
+                {phoneLabel && (
+                  <div className="flex items-center gap-2.5">
+                    <Phone className="size-4 shrink-0 text-muted-foreground" />
+                    <a href={`tel:${phoneLabel}`} className="text-blue-500 underline">
+                      {phoneLabel}
+                    </a>
+                  </div>
+                )}
+
+                {lot.poiTags && lot.poiTags.length > 0 && (
+                  <div className="flex items-start gap-2.5">
+                    <Tag className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                    <div className="flex flex-wrap gap-1.5">
+                      {lot.poiTags.map((tag) => (
+                        <Badge key={tag} variant="outline" className="text-xs">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {lot.notes && (
+                  <p className="text-sm text-muted-foreground bg-gray-50 rounded-lg px-3 py-2">
+                    {lot.notes}
+                  </p>
+                )}
               </div>
-            )}
+            </section>
 
-            {/* 특기사항 */}
-            {lot.notes && (
-              <p className="text-xs text-muted-foreground bg-gray-50 rounded px-2 py-1">
-                {lot.notes}
-              </p>
-            )}
-
-            {/* 리뷰/영상/블로그 탭 */}
-            <ParkingReputationSections lotId={lot.id} />
+            {/* 리뷰/영상/블로그 — 위키 톤 캐로셀 */}
+            <section className="pt-2">
+              <ParkingReputationSections
+                lotId={lot.id}
+                expanded
+                viewAllSlug={slug}
+                initialTabCounts={tabCounts}
+              />
+            </section>
           </div>
         </div>
       </SheetContent>

--- a/src/components/ParkingCard.tsx
+++ b/src/components/ParkingCard.tsx
@@ -37,15 +37,14 @@ import {
   formatPricing,
   formatTotalSpaces,
 } from '@/lib/parking-display'
+import { nearestSnap, type SnapPoints } from '@/lib/sheet-snap'
 import { makeParkingSlug } from '@/lib/slug'
 import { fetchTabCounts } from '@/server/parking'
 import type { ParkingLot } from '@/types/parking'
 
-const COLLAPSED_HEIGHT = 320
-const EXPANDED_HEIGHT_RATIO = 0.85
-const EXPAND_DRAG_THRESHOLD = 20
-const COLLAPSE_DRAG_THRESHOLD = 20
-const CLOSE_DRAG_THRESHOLD_RATIO = 0.5
+const MID_HEIGHT = 320
+const FULL_HEIGHT_RATIO = 0.85
+const CLOSE_DRAG_THRESHOLD = 120
 
 interface ParkingCardProps {
   lot: ParkingLot | null
@@ -57,12 +56,12 @@ interface ParkingCardProps {
 
 export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: ParkingCardProps) {
   const [isMobile, setIsMobile] = useState(true)
-  const [sheetHeight, setSheetHeight] = useState(COLLAPSED_HEIGHT)
+  const [sheetHeight, setSheetHeight] = useState(MID_HEIGHT)
   const [isDragging, setIsDragging] = useState(false)
   const prevLotId = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const dragStartY = useRef(0)
-  const dragStartHeight = useRef(COLLAPSED_HEIGHT)
+  const dragStartHeight = useRef(MID_HEIGHT)
   const lastDragDelta = useRef(0)
 
   const [tabCounts, setTabCounts] = useState<{ reviews: number; blog: number; media: number }>({
@@ -71,24 +70,20 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     media: 0,
   })
 
-  const getExpandedHeight = useCallback(
-    () => Math.max(COLLAPSED_HEIGHT, Math.round(window.innerHeight * EXPANDED_HEIGHT_RATIO)),
+  const getFullHeight = useCallback(
+    () => Math.max(MID_HEIGHT, Math.round(window.innerHeight * FULL_HEIGHT_RATIO)),
     [],
   )
 
+  const getSnapPoints = useCallback(
+    (): SnapPoints => ({ mid: MID_HEIGHT, full: getFullHeight() }),
+    [getFullHeight],
+  )
+
   const clampHeight = useCallback(
-    (height: number) => Math.min(getExpandedHeight(), Math.max(COLLAPSED_HEIGHT, height)),
-    [getExpandedHeight],
+    (height: number) => Math.min(getFullHeight(), Math.max(MID_HEIGHT, height)),
+    [getFullHeight],
   )
-
-  const snapTo = useCallback(
-    (next: 'collapsed' | 'expanded') => {
-      setSheetHeight(next === 'expanded' ? getExpandedHeight() : COLLAPSED_HEIGHT)
-    },
-    [getExpandedHeight],
-  )
-
-  const isExpanded = sheetHeight > COLLAPSED_HEIGHT + 8
 
   useEffect(() => {
     const mql = window.matchMedia('(min-width: 768px)')
@@ -98,11 +93,11 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     return () => mql.removeEventListener('change', handler)
   }, [])
 
-  // 새 주차장 선택 시 접힌 상태로 리셋 + 스크롤 맨 위로
+  // 새 주차장 선택 시 mid 위치로 리셋 + 스크롤 맨 위로
   useEffect(() => {
     if (lot && lot.id !== prevLotId.current) {
       setIsDragging(false)
-      setSheetHeight(COLLAPSED_HEIGHT)
+      setSheetHeight(MID_HEIGHT)
       prevLotId.current = lot.id
       scrollRef.current?.scrollTo(0, 0)
     }
@@ -126,18 +121,6 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     }
   }, [lot])
 
-  // 아래로 스크롤 → 확장
-  const lastScrollTop = useRef(0)
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    const st = el.scrollTop
-    if (!isDragging && !isExpanded && st > lastScrollTop.current) {
-      snapTo('expanded')
-    }
-    lastScrollTop.current = st
-  }, [isDragging, isExpanded, snapTo])
-
   const handleClose = useCallback(() => {
     setIsDragging(false)
     setSheetHeight(0)
@@ -151,14 +134,14 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
 
     const handleResize = () => {
       setSheetHeight((prev) => {
-        if (prev <= COLLAPSED_HEIGHT) return COLLAPSED_HEIGHT
-        return getExpandedHeight()
+        if (prev <= MID_HEIGHT) return MID_HEIGHT
+        return getFullHeight()
       })
     }
 
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
-  }, [getExpandedHeight, isMobile])
+  }, [getFullHeight, isMobile])
 
   const handleDragStart = useCallback(
     (e: React.TouchEvent<HTMLElement>) => {
@@ -185,16 +168,10 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     if (!isDragging) return
 
     const dragDistance = lastDragDelta.current
-    const draggedUp = dragDistance < 0
-    const draggedDown = dragDistance > 0
-
     setIsDragging(false)
 
-    // collapsed에서 아래로 충분히 드래그하면 닫기 (threshold: collapsed 높이의 50%)
-    if (
-      dragStartHeight.current <= COLLAPSED_HEIGHT + 8 &&
-      dragDistance > COLLAPSED_HEIGHT * CLOSE_DRAG_THRESHOLD_RATIO
-    ) {
+    // mid에서 아래로 충분히 드래그하면 닫기 (transition 그대로 적용 → 부드러운 close)
+    if (dragStartHeight.current <= MID_HEIGHT + 8 && dragDistance > CLOSE_DRAG_THRESHOLD) {
       setSheetHeight(0)
       setTimeout(() => {
         onClose()
@@ -202,24 +179,15 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
       return
     }
 
-    if (!isExpanded) {
-      if (draggedUp && Math.abs(dragDistance) >= EXPAND_DRAG_THRESHOLD) {
-        snapTo('expanded')
-        return
-      }
+    // 가장 가까운 스냅 포인트로 이동 (mid / full)
+    const target = nearestSnap(sheetHeight, getSnapPoints())
+    setSheetHeight(target)
 
-      snapTo('collapsed')
-      return
-    }
-
-    if (draggedDown && dragDistance >= COLLAPSE_DRAG_THRESHOLD) {
-      snapTo('collapsed')
+    // mid로 돌아가는 경우 스크롤도 맨 위로
+    if (target === MID_HEIGHT) {
       scrollRef.current?.scrollTo({ top: 0 })
-      return
     }
-
-    snapTo('expanded')
-  }, [onClose, isDragging, isExpanded, snapTo])
+  }, [getSnapPoints, isDragging, onClose, sheetHeight])
 
   if (!lot || !isMobile) return null
 
@@ -247,26 +215,25 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
         }`}
         style={{ height: `${sheetHeight}px` }}
         showCloseButton={false}
-        onTouchStart={handleDragStart}
-        onTouchMove={handleDragMove}
-        onTouchEnd={handleDragEnd}
       >
         <div
           ref={scrollRef}
-          onScroll={handleScroll}
-          className="flex-1 overflow-y-auto overscroll-contain"
+          className={`flex-1 overflow-y-auto overscroll-contain ${
+            isDragging ? 'overflow-hidden' : ''
+          }`}
         >
-          {/* 드래그 핸들 + 닫기 — sticky 고정 */}
-          <div className="sticky top-0 z-10 bg-background">
+          {/* 드래그 핸들 + 닫기 — sticky 고정. touch-none으로 native scroll 차단 */}
+          <div
+            className="sticky top-0 z-10 bg-background touch-none"
+            onTouchStart={handleDragStart}
+            onTouchMove={handleDragMove}
+            onTouchEnd={handleDragEnd}
+          >
             <div className="flex items-center justify-between px-4 pt-1.5">
               <div className="w-8" />
-              <button
-                type="button"
-                onTouchStart={handleDragStart}
-                onTouchMove={handleDragMove}
-                onTouchEnd={handleDragEnd}
-                className="w-10 h-1 rounded-full bg-gray-300 hover:bg-gray-400 transition-colors cursor-grab active:cursor-grabbing outline-none focus:outline-none"
-                aria-label="드래그하여 시트 크기 조절"
+              <div
+                aria-hidden="true"
+                className="w-10 h-1 rounded-full bg-gray-300 cursor-grab active:cursor-grabbing"
               />
               <button
                 type="button"
@@ -284,7 +251,7 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
             </SheetHeader>
           </div>
 
-          <div className="px-4 pb-6 space-y-4">
+          <div className="px-4 pb-safe space-y-4">
             {/* 헤더: 뱃지 + 제목 + 주소 */}
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-1.5">

--- a/src/components/ParkingCard.tsx
+++ b/src/components/ParkingCard.tsx
@@ -5,10 +5,8 @@ import {
   CreditCard,
   Flame,
   MapPin,
-  MessageSquare,
   ParkingSquare,
   Phone,
-  Star,
   Tag,
   ThumbsUp,
   X,
@@ -25,12 +23,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { VoteBookmarkBar } from '@/components/VoteBookmarkBar'
-import {
-  getDifficultyColor,
-  getDifficultyLabel,
-  getDistance,
-  getReliabilityBadge,
-} from '@/lib/geo-utils'
+import { getDifficultyColor, getDistance, getReliabilityBadge } from '@/lib/geo-utils'
 import {
   formatOperatingHours,
   formatPhone,
@@ -193,7 +186,6 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
   if (!lot || !isMobile) return null
 
   const score = lot.difficulty.score
-  const scoreLabel = getDifficultyLabel(score)
   const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
   const summary = lot.curationReason ?? lot.aiSummary
   const operatingHours = formatOperatingHours(lot.operatingHours)
@@ -291,7 +283,7 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
               </div>
             </div>
 
-            {/* 점수 + 평판 근거 2-카드 그리드 */}
+            {/* 점수 + 리뷰/영상/블로그 2-카드 그리드 */}
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-lg border bg-white p-3">
                 <div className="text-xs font-medium text-muted-foreground">쉬움 점수</div>
@@ -301,30 +293,11 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
                   </span>
                   <span className="pb-1 text-sm font-semibold text-muted-foreground">/ 5</span>
                 </div>
-                <div className="mt-2 flex items-center gap-1.5 text-sm font-medium">
-                  <div className="flex items-center gap-0.5">
-                    {[1, 2, 3, 4, 5].map((i) => (
-                      <Star
-                        key={i}
-                        className={`size-3 ${
-                          i <= Math.round(score ?? 0)
-                            ? 'fill-yellow-400 text-yellow-400'
-                            : 'text-gray-300'
-                        }`}
-                      />
-                    ))}
-                  </div>
-                  <span>{scoreLabel}</span>
-                </div>
               </div>
 
               <div className="rounded-lg border bg-white p-3">
-                <div className="text-xs font-medium text-muted-foreground">평판 근거</div>
+                <div className="text-xs font-medium text-muted-foreground">리뷰/영상/블로그</div>
                 <div className="mt-2 text-3xl font-black leading-none">{sourceCount}</div>
-                <div className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                  <MessageSquare className="size-3.5" />
-                  리뷰/영상/웹 글
-                </div>
               </div>
             </div>
 
@@ -337,15 +310,6 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
                 buttonClassName="px-3 py-2 text-sm"
               />
               <VoteBookmarkBar lotId={lot.id} />
-              {lot.phone && (
-                <a
-                  href={`tel:${lot.phone}`}
-                  className="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors hover:bg-zinc-50"
-                >
-                  <Phone className="size-3.5" />
-                  전화
-                </a>
-              )}
               <Link
                 to="/wiki/$slug"
                 params={{ slug }}

--- a/src/components/ParkingCard.tsx
+++ b/src/components/ParkingCard.tsx
@@ -80,8 +80,9 @@ export function ParkingCard({ lot, onClose, userLat, userLng, userLocated }: Par
     [getFullHeight],
   )
 
+  // 드래그 중에는 0까지 따라가도록 허용 (mid → close 드래그 시 시각 피드백)
   const clampHeight = useCallback(
-    (height: number) => Math.min(getFullHeight(), Math.max(MID_HEIGHT, height)),
+    (height: number) => Math.min(getFullHeight(), Math.max(0, height)),
     [getFullHeight],
   )
 

--- a/src/components/ParkingDetailPanel.tsx
+++ b/src/components/ParkingDetailPanel.tsx
@@ -5,18 +5,28 @@ import {
   CreditCard,
   Flame,
   MapPin,
-  Navigation,
+  MessageSquare,
   ParkingSquare,
   Phone,
   Star,
+  Tag,
   ThumbsUp,
   X,
 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { NavigationButton } from '@/components/NavigationButton'
 import { ParkingReputationSections } from '@/components/ParkingReputationSections'
 import { Badge } from '@/components/ui/badge'
 import { VoteBookmarkBar } from '@/components/VoteBookmarkBar'
+import { getDifficultyLabel, getReliabilityBadge } from '@/lib/geo-utils'
+import {
+  formatOperatingHours,
+  formatPhone,
+  formatPricing,
+  formatTotalSpaces,
+} from '@/lib/parking-display'
 import { makeParkingSlug } from '@/lib/slug'
+import { fetchTabCounts } from '@/server/parking'
 import type { ParkingLot } from '@/types/parking'
 
 interface ParkingDetailPanelProps {
@@ -28,207 +38,270 @@ interface ParkingDetailPanelProps {
 }
 
 export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
-  const rating = lot.difficulty.score ?? 0
+  const score = lot.difficulty.score
+  const scoreLabel = getDifficultyLabel(score)
+  const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
+  const summary = lot.curationReason ?? lot.aiSummary
+  const operatingHours = formatOperatingHours(lot.operatingHours)
+  const pricing = formatPricing(lot.pricing)
+  const totalSpacesLabel = formatTotalSpaces(lot.totalSpaces)
+  const phoneLabel = formatPhone(lot.phone)
+  const slug = makeParkingSlug(lot.name, lot.id)
+  const hasAiTips = Boolean(lot.aiTipPricing || lot.aiTipVisit || lot.aiTipAlternative)
+  const hasContentAbove = Boolean(summary) || hasAiTips
+
+  const [tabCounts, setTabCounts] = useState<{ reviews: number; blog: number; media: number }>({
+    reviews: 0,
+    blog: 0,
+    media: 0,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTabCounts({ data: { parkingLotId: lot.id } })
+      .then((counts) => {
+        if (!cancelled) setTabCounts(counts)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [lot.id])
+
+  const sourceCount = tabCounts.reviews + tabCounts.blog + tabCounts.media
 
   return (
-    <div className="w-[360px] shrink-0 flex-col bg-white/95 backdrop-blur-sm rounded-xl shadow-lg border pointer-events-auto flex overflow-hidden animate-in slide-in-from-left-4 duration-150">
-      {/* 히어로 이미지 */}
-      <div className="relative shrink-0 h-40 bg-gradient-to-br from-blue-100 to-blue-50 flex items-center justify-center overflow-hidden">
-        <div className="absolute inset-0 opacity-10">
-          <ParkingSquare className="size-32 text-blue-500" />
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute top-2 right-2 p-1.5 rounded-md bg-white/90 hover:bg-white shadow-sm transition-colors cursor-pointer z-10"
-        >
-          <X className="size-4 text-muted-foreground" />
-        </button>
-      </div>
+    <div className="w-[400px] shrink-0 flex-col bg-white/95 backdrop-blur-sm rounded-xl shadow-lg border pointer-events-auto flex overflow-hidden animate-in slide-in-from-left-4 duration-150">
+      <div className="flex-1 overflow-y-auto">
+        {/* 헤더 */}
+        <section className="relative border-b bg-white px-5 pt-5 pb-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-3 top-3 p-1.5 rounded-md bg-white/90 hover:bg-gray-100 transition-colors cursor-pointer"
+            aria-label="닫기"
+          >
+            <X className="size-4 text-muted-foreground" />
+          </button>
 
-      {/* 헤더 */}
-      <div className="shrink-0 border-b px-4 py-4">
-        {/* 제목 + 평점 + 상태 */}
-        <div className="flex items-start justify-between gap-2 mb-3">
-          <div className="flex-1 min-w-0">
-            <h2 className="font-bold text-xl mb-1.5">{lot.name}</h2>
-            {/* 평점 표시 */}
-            <div className="flex items-center gap-1.5">
-              <div className="flex items-center gap-0.5">
-                {[1, 2, 3, 4, 5].map((i) => (
-                  <Star
-                    key={i}
-                    className={`size-3.5 ${
-                      i <= Math.round(rating) ? 'fill-yellow-400 text-yellow-400' : 'text-gray-300'
-                    }`}
-                  />
-                ))}
+          <div className="space-y-4 pr-8">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>
+                  {lot.pricing.isFree ? '무료' : '유료'}
+                </Badge>
+                <Badge variant="outline">{lot.type}</Badge>
+                {score !== null && score >= 4.0 && (
+                  <Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100">
+                    <ThumbsUp className="size-3" />
+                    초보 추천
+                  </Badge>
+                )}
+                {score !== null && score < 2.0 && (
+                  <Badge variant="destructive" className="gap-1">
+                    <Flame className="size-3" />
+                    초보 주의
+                  </Badge>
+                )}
               </div>
-              <span className="text-base font-semibold">{rating.toFixed(1)}</span>
-              {lot.difficulty.reviewCount > 0 && (
-                <span className="text-sm text-muted-foreground ml-0.5">
-                  리뷰 {lot.difficulty.reviewCount}개
-                </span>
+              <h2 className="text-2xl font-bold leading-tight tracking-normal">{lot.name}</h2>
+              <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                <MapPin className="mt-0.5 size-4 shrink-0" />
+                <span>{lot.address}</span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg border bg-white p-3">
+                <div className="text-xs font-medium text-muted-foreground">쉬움 점수</div>
+                <div className="mt-2 flex items-end gap-2">
+                  <span className="text-3xl font-black leading-none">
+                    {score === null ? '-' : score.toFixed(1)}
+                  </span>
+                  <span className="pb-1 text-sm font-semibold text-muted-foreground">/ 5</span>
+                </div>
+                <div className="mt-2 flex items-center gap-1.5 text-sm font-medium">
+                  <div className="flex items-center gap-0.5">
+                    {[1, 2, 3, 4, 5].map((i) => (
+                      <Star
+                        key={i}
+                        className={`size-3 ${
+                          i <= Math.round(score ?? 0)
+                            ? 'fill-yellow-400 text-yellow-400'
+                            : 'text-gray-300'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <span>{scoreLabel}</span>
+                </div>
+              </div>
+
+              <div className="rounded-lg border bg-white p-3">
+                <div className="text-xs font-medium text-muted-foreground">평판 근거</div>
+                <div className="mt-2 text-3xl font-black leading-none">{sourceCount}</div>
+                <div className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <MessageSquare className="size-3.5" />
+                  리뷰/영상/웹 글
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <NavigationButton
+                lat={lot.lat}
+                lng={lot.lng}
+                name={lot.name}
+                buttonClassName="px-3 py-2 text-sm"
+              />
+              <VoteBookmarkBar lotId={lot.id} />
+              {lot.phone && (
+                <a
+                  href={`tel:${lot.phone}`}
+                  className="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors hover:bg-zinc-50"
+                >
+                  <Phone className="size-3.5" />
+                  전화
+                </a>
+              )}
+              <Link
+                to="/wiki/$slug"
+                params={{ slug }}
+                className="ml-auto inline-flex items-center gap-1 px-2.5 py-2 text-sm font-medium rounded-lg border hover:bg-gray-50 transition-colors"
+              >
+                자세히
+                <ChevronRight className="size-3" />
+              </Link>
+            </div>
+            {reliabilityBadge && (
+              <Badge variant="outline" className={reliabilityBadge.className}>
+                {reliabilityBadge.label}
+              </Badge>
+            )}
+          </div>
+        </section>
+
+        {/* 컨텐츠 */}
+        <div className="px-5 py-5 space-y-4">
+          {summary && (
+            <section className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+              <div className="mb-2 text-xs font-semibold text-blue-700">AI 요약</div>
+              <p className="whitespace-pre-line text-sm font-medium leading-relaxed text-zinc-900">
+                {summary}
+              </p>
+              {lot.featuredSource === '1010' && (
+                <p className="mt-3 pt-2 border-t border-blue-200 text-xs text-blue-700/80">
+                  📺 10시10분 유튜브 채널에 소개된 주차장
+                </p>
+              )}
+            </section>
+          )}
+
+          {hasAiTips && (
+            <section className="grid grid-cols-1 gap-2">
+              {lot.aiTipPricing && (
+                <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                  <span className="mb-1 block text-sm font-semibold text-gray-900">요금</span>
+                  {lot.aiTipPricing}
+                </div>
+              )}
+              {lot.aiTipVisit && (
+                <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                  <span className="mb-1 block text-sm font-semibold text-gray-900">방문 팁</span>
+                  {lot.aiTipVisit}
+                </div>
+              )}
+              {lot.aiTipAlternative && (
+                <div className="rounded-lg border bg-white px-4 py-3 text-sm leading-relaxed text-gray-700">
+                  <span className="mb-1 block text-sm font-semibold text-gray-900">대안</span>
+                  {lot.aiTipAlternative}
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* 기본 정보 */}
+          <section
+            className={hasContentAbove ? 'border-t-2 border-zinc-300 pt-6 pb-2' : 'pt-1 pb-2'}
+          >
+            <h3 className="mb-3 text-base font-bold">주차장 정보</h3>
+            <div className="space-y-3 text-sm">
+              <div className="flex items-start gap-2.5">
+                <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <span>{lot.address}</span>
+              </div>
+
+              <div className="flex items-start gap-2.5">
+                <Clock className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className={operatingHours.isUnknown ? 'text-muted-foreground' : ''}>
+                    {operatingHours.primary}
+                  </div>
+                  {operatingHours.secondary && (
+                    <div className="text-xs text-muted-foreground">{operatingHours.secondary}</div>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2.5">
+                <CreditCard className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className={pricing.isUnknown ? 'text-muted-foreground' : ''}>
+                    {pricing.primary}
+                  </div>
+                  {pricing.secondary && (
+                    <div className="text-xs text-muted-foreground">{pricing.secondary}</div>
+                  )}
+                </div>
+              </div>
+
+              {totalSpacesLabel && (
+                <div className="flex items-center gap-2.5">
+                  <ParkingSquare className="size-4 shrink-0 text-muted-foreground" />
+                  <span>{totalSpacesLabel}</span>
+                </div>
+              )}
+
+              {phoneLabel && (
+                <div className="flex items-center gap-2.5">
+                  <Phone className="size-4 shrink-0 text-muted-foreground" />
+                  <a href={`tel:${phoneLabel}`} className="text-blue-500 underline">
+                    {phoneLabel}
+                  </a>
+                </div>
+              )}
+
+              {lot.poiTags && lot.poiTags.length > 0 && (
+                <div className="flex items-start gap-2.5">
+                  <Tag className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div className="flex flex-wrap gap-1.5">
+                    {lot.poiTags.map((tag) => (
+                      <Badge key={tag} variant="outline" className="text-xs">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {lot.notes && (
+                <p className="text-sm text-muted-foreground bg-gray-50 rounded-lg px-3 py-2">
+                  {lot.notes}
+                </p>
               )}
             </div>
-          </div>
+          </section>
+
+          {/* 리뷰/영상/블로그 — 위키 톤 캐로셀 */}
+          <section className="pt-2">
+            <ParkingReputationSections
+              lotId={lot.id}
+              expanded
+              viewAllSlug={slug}
+              initialTabCounts={tabCounts}
+            />
+          </section>
         </div>
-
-        {/* 상태 배지 */}
-        <div className="flex items-center gap-2 flex-wrap mb-3">
-          <Badge className="bg-green-500 hover:bg-green-600 text-white text-sm">주차 가능</Badge>
-          <Badge variant={lot.pricing.isFree ? 'default' : 'outline'} className="text-sm">
-            {lot.pricing.isFree ? '무료' : '유료'}
-          </Badge>
-          {lot.difficulty.score !== null && lot.difficulty.score >= 4.0 && (
-            <Badge className="text-sm gap-1 bg-green-100 text-green-700 hover:bg-green-100">
-              <ThumbsUp className="size-3" />
-              초보 추천
-            </Badge>
-          )}
-          {lot.difficulty.score !== null && lot.difficulty.score < 2.0 && (
-            <Badge variant="destructive" className="text-sm gap-1">
-              <Flame className="size-3" />
-              초보 주의
-            </Badge>
-          )}
-        </div>
-
-        {/* 액션 버튼 */}
-        <div className="flex items-center gap-2">
-          <NavigationButton lat={lot.lat} lng={lot.lng} name={lot.name} />
-          <VoteBookmarkBar lotId={lot.id} />
-          <Link
-            to="/wiki/$slug"
-            params={{ slug: makeParkingSlug(lot.name, lot.id) }}
-            className="inline-flex items-center gap-1 px-2.5 py-1.5 text-sm font-medium rounded-md border hover:bg-gray-50 transition-colors"
-          >
-            자세히
-            <ChevronRight className="size-3" />
-          </Link>
-        </div>
-      </div>
-
-      {/* 상세 정보 */}
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-        {/* AI 요약 + 팁 */}
-        {(lot.aiSummary || lot.aiTipPricing || lot.aiTipVisit || lot.aiTipAlternative) && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 overflow-hidden text-base">
-            {lot.aiSummary && (
-              <div className="px-3.5 py-3 space-y-1.5">
-                <div className="font-semibold flex items-center gap-1.5 text-blue-900">
-                  ✨ AI 요약
-                </div>
-                <p className="whitespace-pre-line text-blue-800 leading-snug">{lot.aiSummary}</p>
-                {lot.featuredSource === '1010' && (
-                  <p className="text-sm text-muted-foreground pt-2 border-t border-blue-200">
-                    📺 10시10분 유튜브 채널에 소개된 주차장
-                  </p>
-                )}
-              </div>
-            )}
-            {(lot.aiTipPricing || lot.aiTipVisit || lot.aiTipAlternative) && (
-              <div className="px-3.5 py-3 bg-white/60 border-t border-blue-100 space-y-2">
-                {lot.aiTipPricing && (
-                  <p className="text-sm text-gray-700">
-                    <span className="font-medium text-gray-800">요금</span> {lot.aiTipPricing}
-                  </p>
-                )}
-                {lot.aiTipVisit && (
-                  <p className="text-sm text-gray-700">
-                    <span className="font-medium text-gray-800">방문</span> {lot.aiTipVisit}
-                  </p>
-                )}
-                {lot.aiTipAlternative && (
-                  <p className="text-sm text-gray-700">
-                    <span className="font-medium text-gray-800">대안</span> {lot.aiTipAlternative}
-                  </p>
-                )}
-                <p className="text-[11px] text-gray-400 pt-1 border-t border-gray-100">
-                  ※ 블로그·리뷰 기반 AI 요약으로 실제와 다를 수 있습니다.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* 주소 */}
-        <div className="flex items-start gap-2.5 text-base">
-          <MapPin className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-          <span>{lot.address}</span>
-        </div>
-
-        {/* 운영시간 */}
-        <div className="flex items-start gap-2.5 text-base">
-          <Clock className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-          <div>
-            <div>
-              평일 {lot.operatingHours.weekday.start}-{lot.operatingHours.weekday.end}
-            </div>
-            <div className="text-sm text-muted-foreground">
-              토 {lot.operatingHours.saturday.start}-{lot.operatingHours.saturday.end} · 공휴일{' '}
-              {lot.operatingHours.holiday.start}-{lot.operatingHours.holiday.end}
-            </div>
-          </div>
-        </div>
-
-        {/* 요금 */}
-        {!lot.pricing.isFree && (
-          <div className="flex items-start gap-2.5 text-base">
-            <CreditCard className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-            <div>
-              <div>
-                기본 {lot.pricing.baseTime}분 {lot.pricing.baseFee.toLocaleString()}원
-              </div>
-              <div className="text-sm text-muted-foreground">
-                추가 {lot.pricing.extraTime}분당 {lot.pricing.extraFee.toLocaleString()}원
-                {lot.pricing.dailyMax && ` · 1일 최대 ${lot.pricing.dailyMax.toLocaleString()}원`}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* 주차면수 */}
-        {lot.totalSpaces > 0 && (
-          <div className="flex items-center gap-2.5 text-base">
-            <ParkingSquare className="size-4 shrink-0 text-muted-foreground" />
-            <span>총 {lot.totalSpaces}면</span>
-          </div>
-        )}
-
-        {/* 전화번호 */}
-        {lot.phone && (
-          <div className="flex items-center gap-2.5 text-base">
-            <Phone className="size-4 shrink-0 text-muted-foreground" />
-            <a href={`tel:${lot.phone}`} className="text-blue-500 underline">
-              {lot.phone}
-            </a>
-          </div>
-        )}
-
-        {/* POI 태그 */}
-        {lot.poiTags && lot.poiTags.length > 0 && (
-          <div className="flex items-start gap-2.5 text-base">
-            <Navigation className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-            <div className="flex flex-wrap gap-1.5">
-              {lot.poiTags.map((tag) => (
-                <Badge key={tag} variant="outline" className="text-sm">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* 특기사항 */}
-        {lot.notes && (
-          <p className="text-sm text-muted-foreground bg-gray-50 rounded-lg px-3 py-2">
-            {lot.notes}
-          </p>
-        )}
-
-        {/* 탭 영역 */}
-        <ParkingReputationSections lotId={lot.id} />
       </div>
     </div>
   )

--- a/src/components/ParkingDetailPanel.tsx
+++ b/src/components/ParkingDetailPanel.tsx
@@ -5,10 +5,8 @@ import {
   CreditCard,
   Flame,
   MapPin,
-  MessageSquare,
   ParkingSquare,
   Phone,
-  Star,
   Tag,
   ThumbsUp,
   X,
@@ -18,7 +16,7 @@ import { NavigationButton } from '@/components/NavigationButton'
 import { ParkingReputationSections } from '@/components/ParkingReputationSections'
 import { Badge } from '@/components/ui/badge'
 import { VoteBookmarkBar } from '@/components/VoteBookmarkBar'
-import { getDifficultyLabel, getReliabilityBadge } from '@/lib/geo-utils'
+import { getReliabilityBadge } from '@/lib/geo-utils'
 import {
   formatOperatingHours,
   formatPhone,
@@ -39,7 +37,6 @@ interface ParkingDetailPanelProps {
 
 export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
   const score = lot.difficulty.score
-  const scoreLabel = getDifficultyLabel(score)
   const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
   const summary = lot.curationReason ?? lot.aiSummary
   const operatingHours = formatOperatingHours(lot.operatingHours)
@@ -120,30 +117,11 @@ export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
                   </span>
                   <span className="pb-1 text-sm font-semibold text-muted-foreground">/ 5</span>
                 </div>
-                <div className="mt-2 flex items-center gap-1.5 text-sm font-medium">
-                  <div className="flex items-center gap-0.5">
-                    {[1, 2, 3, 4, 5].map((i) => (
-                      <Star
-                        key={i}
-                        className={`size-3 ${
-                          i <= Math.round(score ?? 0)
-                            ? 'fill-yellow-400 text-yellow-400'
-                            : 'text-gray-300'
-                        }`}
-                      />
-                    ))}
-                  </div>
-                  <span>{scoreLabel}</span>
-                </div>
               </div>
 
               <div className="rounded-lg border bg-white p-3">
-                <div className="text-xs font-medium text-muted-foreground">평판 근거</div>
+                <div className="text-xs font-medium text-muted-foreground">리뷰/영상/블로그</div>
                 <div className="mt-2 text-3xl font-black leading-none">{sourceCount}</div>
-                <div className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                  <MessageSquare className="size-3.5" />
-                  리뷰/영상/웹 글
-                </div>
               </div>
             </div>
 
@@ -155,15 +133,6 @@ export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
                 buttonClassName="px-3 py-2 text-sm"
               />
               <VoteBookmarkBar lotId={lot.id} />
-              {lot.phone && (
-                <a
-                  href={`tel:${lot.phone}`}
-                  className="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors hover:bg-zinc-50"
-                >
-                  <Phone className="size-3.5" />
-                  전화
-                </a>
-              )}
               <Link
                 to="/wiki/$slug"
                 params={{ slug }}

--- a/src/lib/sheet-snap.ts
+++ b/src/lib/sheet-snap.ts
@@ -1,0 +1,24 @@
+/**
+ * 바텀시트 스냅 포인트 유틸리티.
+ * 시트 높이를 px 단위로 다루며, 드래그 종료 시 가장 가까운 스냅 위치를 반환한다.
+ */
+
+export interface SnapPoints {
+  mid: number
+  full: number
+}
+
+/** 후보 스냅 높이들 중 currentHeight와 가장 가까운 값을 반환 */
+export function nearestSnap(currentHeight: number, snaps: SnapPoints): number {
+  const candidates = [snaps.mid, snaps.full]
+  let best = candidates[0]
+  let bestDist = Math.abs(currentHeight - best)
+  for (const candidate of candidates) {
+    const dist = Math.abs(currentHeight - candidate)
+    if (dist < bestDist) {
+      best = candidate
+      bestDist = dist
+    }
+  }
+  return best
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -30,7 +30,8 @@ export const Route = createRootRoute({
       },
       {
         name: 'viewport',
-        content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no',
+        content:
+          'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover',
       },
       {
         title: SITE_TITLE,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,10 @@ import type { ParkingPoint } from '@/server/parking'
 import { fetchAllParkingPoints, fetchParkingDetail, fetchParkingLots } from '@/server/parking'
 import type { MapBounds, ParkingLot } from '@/types/parking'
 
+const DETAIL_PANEL_WIDTH = 400
+const FILTER_LEFT_CLOSED = 296
+const FILTER_LEFT_OPENED = 12 + 280 + 8 + DETAIL_PANEL_WIDTH
+
 export const Route = createFileRoute('/')({
   validateSearch: (search: Record<string, unknown>) => ({
     lotId: typeof search.lotId === 'string' ? search.lotId : undefined,
@@ -251,7 +255,7 @@ function App() {
         {/* 필터 — 사이드바 오른쪽, 상세패널 열리면 더 오른쪽 */}
         <div
           className="hidden md:block absolute top-3 z-20 pointer-events-auto transition-[left] duration-200"
-          style={{ left: selectedLot ? '660px' : '296px' }}
+          style={{ left: selectedLot ? `${FILTER_LEFT_OPENED}px` : `${FILTER_LEFT_CLOSED}px` }}
         >
           <FloatingFilters
             filters={filters}

--- a/src/routes/wiki/$slug.tsx
+++ b/src/routes/wiki/$slug.tsx
@@ -5,10 +5,8 @@ import {
   CreditCard,
   Flame,
   MapPin,
-  MessageSquare,
   ParkingSquare,
   Phone,
-  Star,
   Tag,
   ThumbsUp,
 } from 'lucide-react'
@@ -197,7 +195,6 @@ function NearbyPlacesSection({ places }: { places: NearbyPlaceInfo[] }) {
 function WikiDetailPage() {
   const { lot, nearbyPlaces, blogPosts, media, reviews, tabCounts } = Route.useLoaderData()
   const score = lot.difficulty.score
-  const scoreLabel = getDifficultyLabel(score)
   const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
   const sourceCount = tabCounts.reviews + tabCounts.blog + tabCounts.media
   const summary = lot.curationReason ?? lot.aiSummary
@@ -254,30 +251,11 @@ function WikiDetailPage() {
                     </span>
                     <span className="pb-1 text-sm font-semibold text-muted-foreground">/ 5</span>
                   </div>
-                  <div className="mt-2 flex items-center gap-1.5 text-sm font-medium">
-                    <div className="flex items-center gap-0.5">
-                      {[1, 2, 3, 4, 5].map((i) => (
-                        <Star
-                          key={i}
-                          className={`size-3.5 ${
-                            i <= Math.round(score ?? 0)
-                              ? 'fill-yellow-400 text-yellow-400'
-                              : 'text-gray-300'
-                          }`}
-                        />
-                      ))}
-                    </div>
-                    <span>{scoreLabel}</span>
-                  </div>
                 </div>
 
                 <div className="rounded-lg border bg-white p-4">
-                  <div className="text-xs font-medium text-muted-foreground">평판 근거</div>
+                  <div className="text-xs font-medium text-muted-foreground">리뷰/영상/블로그</div>
                   <div className="mt-2 text-4xl font-black leading-none">{sourceCount}</div>
-                  <div className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                    <MessageSquare className="size-3.5" />
-                    리뷰/영상/웹 글
-                  </div>
                 </div>
               </div>
 
@@ -289,15 +267,6 @@ function WikiDetailPage() {
                   buttonClassName="px-4 py-2 text-sm"
                 />
                 <VoteBookmarkBar lotId={lot.id} />
-                {lot.phone && (
-                  <a
-                    href={`tel:${lot.phone}`}
-                    className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-zinc-50"
-                  >
-                    <Phone className="size-3.5" />
-                    전화
-                  </a>
-                )}
               </div>
               {reliabilityBadge && (
                 <Badge variant="outline" className={reliabilityBadge.className}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -154,3 +154,8 @@ code {
 .search-dropdown-scroll::-webkit-scrollbar-thumb:hover {
   background-color: rgba(0, 0, 0, 0.35);
 }
+
+/* Safe area utilities — viewport-fit=cover 와 함께 사용 */
+@utility pb-safe {
+  padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+}


### PR DESCRIPTION
## Summary
- 지도 페이지의 데스크톱 상세 패널(`ParkingDetailPanel`)과 모바일 바텀시트(`ParkingCard`)를 위키 페이지(`/wiki/$slug`) 디자인 톤으로 통일
- Issue #82 해결: 모바일 바텀시트 스냅 포인트 개선(2-stop) + safe-area + 스크롤/드래그 버그 수정
- 점수 카드 단순화(별표/레이블 제거) + 액션 행 전화 버튼 제거

## Closes
Closes #82

## 주요 변경 사항

### 1. 지도 상세 패널을 위키 톤으로 통일 (`55019c4`)
- 데스크톱 패널 폭 360 → **400px**, 히어로 그라디언트 영역 제거
- `주차 가능` 뱃지 제거 → `무료/유료` + `lot.type` + `초보 추천/주의`만 유지
- **2-카드 그리드** 도입 (쉬움 점수 / 평판 근거)
- AI 요약·팁을 위키 양식 카드 그리드로 교체
- `border-t-2 border-zinc-300` 정보 섹션 구분선 적용
- 평판 섹션을 `expanded` 캐로셀 모드(세로 4섹션)로 변경
- `reliabilityBadge` 추가, formatters(`formatOperatingHours`/`formatPricing` 등) 적용
- 모바일 카드: AI 요약 빨강/파랑 분기 제거 → 항상 파란 카드(위키톤 통일)

### 2. 모바일 바텀시트 2-stop 스냅 (`180f516` / `3e87538`) — Issue #82
- `mid (320px)` / `full (85vh)` 2-stop 스냅, 시작 위치 mid
- 드래그 종료 시 `nearestSnap()` 헬퍼로 가장 가까운 스냅 포인트로 이동
- mid에서 추가 120px 아래로 드래그 시 부드러운 transition으로 close
- **드래그 중 시각 피드백 수정**: `clampHeight` 하한을 0으로 완화해 손가락 따라 시트가 줄어들도록
- **스크롤 자동 expand 제거** (의도치 않은 확장 방지)
- **핸들 드래그 시 콘텐츠가 함께 스크롤되던 버그 수정** — sticky 헤더에 `touch-none`, 드래그 중 `overflow-hidden`, SheetContent 중복 핸들러 제거
- **viewport-fit=cover** 추가 + `@utility pb-safe` 정의 → 노치 기기 대응
- `src/lib/sheet-snap.ts` 신설 (순수 헬퍼)

### 3. 점수 카드 단순화 + 전화 버튼 제거 (`133abf2`)
- 쉬움 점수 카드: 별 5개 + 난이도 레이블 제거 → 점수 숫자만 표시
- 평판 근거 카드: 타이틀 `평판 근거` → `리뷰/영상/블로그`, 하단 아이콘+중복 텍스트 제거
- 액션 행 전화 버튼 삭제 (정보 섹션의 전화번호 행은 유지)
- 미사용 import 정리

## 변경된 파일
- `src/routes/wiki/\$slug.tsx` — 점수 카드 단순화, 전화 버튼 제거
- `src/routes/__root.tsx` — viewport-fit=cover 추가
- `src/routes/index.tsx` — 데스크톱 패널 좌측 오프셋 상수화
- `src/components/ParkingDetailPanel.tsx` — 데스크톱 위키 톤 리디자인
- `src/components/ParkingCard.tsx` — 모바일 시트 리디자인 + 2-stop 스냅 + 스크롤 버그 수정
- `src/lib/sheet-snap.ts` — 신설 (nearestSnap 헬퍼)
- `src/styles.css` — pb-safe 유틸 정의

## Test plan
- [ ] 데스크톱 1440px: 패널 400px가 사이드바와 floating filter를 가리지 않는지 확인
- [ ] 데스크톱 1024px: 패널이 지도 절반 이상을 덮지 않는지 확인
- [ ] 모바일 375px: 시트 mid 위치에서 헤더+뱃지+2-카드 그리드+액션 행이 cutoff 없이 들어가는지
- [ ] 모바일 320px: 2-카드 그리드가 깨지지 않는지
- [ ] mid → full 드래그 시 부드러운 height 애니메이션
- [ ] mid → close 드래그 시 시트가 손가락을 따라 줄어드는지(시각 피드백)
- [ ] 핸들 드래그 시 콘텐츠가 함께 스크롤되지 않는지
- [ ] 스크롤로 인한 자동 expand 발생 없음 회귀 확인
- [ ] iPhone 14 Pro 노치 기기에서 하단 콘텐츠 잘리지 않음
- [ ] 평판 캐로셀 가로 swipe와 시트 세로 drag 충돌 없음
- [ ] \`featuredSource === '1010'\` 주차장에서 1010 안내 줄 노출
- [ ] 점수 < 2.0 / ≥ 4.0 / null 케이스 모두 뱃지 분기 정상
- [ ] wiki 페이지의 점수/평판 카드 디자인이 모바일 시트와 일치