### PR TITLE
✨ 데스크톱 지도 패널 List ↔ Detail 가로 슬라이드 전환

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "parking-map",
@@ -20,6 +19,7 @@
         "drizzle-orm": "^0.45.1",
         "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.561.0",
+        "motion": "^12.38.0",
         "node-html-markdown": "^2.0.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
@@ -895,6 +895,8 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
@@ -1072,6 +1074,12 @@
     "mongodb": ["mongodb@7.1.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg=="],
 
     "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
+
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "drizzle-orm": "^0.45.1",
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.561.0",
+    "motion": "^12.38.0",
     "node-html-markdown": "^2.0.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",

--- a/src/components/DesktopMapPanel.tsx
+++ b/src/components/DesktopMapPanel.tsx
@@ -7,6 +7,7 @@ import type { ParkingLot } from '@/types/parking'
 interface DesktopMapPanelProps {
   parkingLots: ParkingLot[]
   selectedLot: ParkingLot | null
+  viewMode: 'list' | 'detail'
   hoveredLotId: string | null
   onSelect: (lot: ParkingLot) => void
   onHover: (id: string | null) => void
@@ -23,6 +24,7 @@ const SLIDE_EASE = [0.16, 1, 0.3, 1] as const
 export function DesktopMapPanel({
   parkingLots,
   selectedLot,
+  viewMode,
   hoveredLotId,
   onSelect,
   onHover,
@@ -34,16 +36,17 @@ export function DesktopMapPanel({
 }: DesktopMapPanelProps) {
   const reduced = useReducedMotion()
   const dur = reduced ? 0 : SLIDE_DURATION
+  const showDetail = viewMode === 'detail' && selectedLot !== null
 
   // ESC로 detail에서 list로 pop
   useEffect(() => {
-    if (!selectedLot) return
+    if (!showDetail) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onCloseDetail()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [selectedLot, onCloseDetail])
+  }, [showDetail, onCloseDetail])
 
   return (
     <aside
@@ -51,7 +54,7 @@ export function DesktopMapPanel({
       aria-label="주차장 패널"
     >
       <AnimatePresence mode="wait" initial={false}>
-        {selectedLot ? (
+        {showDetail && selectedLot ? (
           <motion.div
             key="detail"
             className="absolute inset-0"
@@ -79,7 +82,7 @@ export function DesktopMapPanel({
           >
             <ParkingSidebar
               parkingLots={parkingLots}
-              selectedLotId={null}
+              selectedLotId={selectedLot?.id ?? null}
               hoveredLotId={hoveredLotId}
               onSelect={onSelect}
               onHover={onHover}

--- a/src/components/DesktopMapPanel.tsx
+++ b/src/components/DesktopMapPanel.tsx
@@ -50,7 +50,7 @@ export function DesktopMapPanel({
 
   return (
     <aside
-      className="relative w-[400px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
+      className="relative w-[360px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
       aria-label="주차장 패널"
     >
       <AnimatePresence mode="wait" initial={false}>

--- a/src/components/DesktopMapPanel.tsx
+++ b/src/components/DesktopMapPanel.tsx
@@ -53,7 +53,7 @@ export function DesktopMapPanel({
       className="relative w-[360px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
       aria-label="주차장 패널"
     >
-      <AnimatePresence mode="wait" initial={false}>
+      <AnimatePresence mode="sync" initial={false}>
         {showDetail && selectedLot ? (
           <motion.div
             key="detail"

--- a/src/components/DesktopMapPanel.tsx
+++ b/src/components/DesktopMapPanel.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft, ParkingSquare } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { useEffect } from 'react'
 import { ParkingDetailPanel } from '@/components/ParkingDetailPanel'
@@ -19,6 +20,7 @@ interface DesktopMapPanelProps {
 }
 
 const SLIDE_DURATION = 0.25
+const HEADER_FADE_DURATION = 0.15
 const SLIDE_EASE = [0.16, 1, 0.3, 1] as const
 
 export function DesktopMapPanel({
@@ -35,7 +37,8 @@ export function DesktopMapPanel({
   mapCenter,
 }: DesktopMapPanelProps) {
   const reduced = useReducedMotion()
-  const dur = reduced ? 0 : SLIDE_DURATION
+  const slideDur = reduced ? 0 : SLIDE_DURATION
+  const fadeDur = reduced ? 0 : HEADER_FADE_DURATION
   const showDetail = viewMode === 'detail' && selectedLot !== null
 
   // ESC로 detail에서 list로 pop
@@ -50,50 +53,93 @@ export function DesktopMapPanel({
 
   return (
     <aside
-      className="relative w-[360px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
+      className="flex flex-col w-[360px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
       aria-label="주차장 패널"
     >
-      <AnimatePresence mode="sync" initial={false}>
-        {showDetail && selectedLot ? (
-          <motion.div
-            key="detail"
-            className="absolute inset-0"
-            initial={{ x: '100%' }}
-            animate={{ x: 0 }}
-            exit={{ x: '100%' }}
-            transition={{ duration: dur, ease: SLIDE_EASE }}
-          >
-            <ParkingDetailPanel
-              lot={selectedLot}
-              onClose={onCloseDetail}
-              userLat={userLat}
-              userLng={userLng}
-              userLocated={userLocated}
-            />
-          </motion.div>
-        ) : (
-          <motion.div
-            key="list"
-            className="absolute inset-0"
-            initial={{ x: '-100%' }}
-            animate={{ x: 0 }}
-            exit={{ x: '-100%' }}
-            transition={{ duration: dur, ease: SLIDE_EASE }}
-          >
-            <ParkingSidebar
-              parkingLots={parkingLots}
-              selectedLotId={selectedLot?.id ?? null}
-              hoveredLotId={hoveredLotId}
-              onSelect={onSelect}
-              onHover={onHover}
-              userLat={userLat}
-              userLng={userLng}
-              userLocated={userLocated}
-              mapCenter={mapCenter}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* Persistent header — 슬라이드되지 않음 */}
+      <header className="shrink-0 h-12 px-3 flex items-center border-b bg-white relative">
+        <AnimatePresence mode="wait" initial={false}>
+          {showDetail ? (
+            <motion.div
+              key="detail-header"
+              className="absolute inset-0 px-3 flex items-center"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: fadeDur }}
+            >
+              <button
+                type="button"
+                onClick={onCloseDetail}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-gray-100 transition-colors cursor-pointer"
+                aria-label="목록으로 돌아가기"
+              >
+                <ChevronLeft className="size-4" />
+                목록
+              </button>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="list-header"
+              className="absolute inset-0 px-4 flex items-center justify-between"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: fadeDur }}
+            >
+              <div className="flex items-center gap-2">
+                <ParkingSquare className="size-4 text-blue-500" />
+                <span className="font-semibold text-base">주차장 목록</span>
+              </div>
+              <span className="text-sm text-muted-foreground">{parkingLots.length}개</span>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </header>
+
+      {/* 슬라이드되는 body */}
+      <div className="relative flex-1 overflow-hidden">
+        <AnimatePresence mode="sync" initial={false}>
+          {showDetail && selectedLot ? (
+            <motion.div
+              key="detail"
+              className="absolute inset-0"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ duration: slideDur, ease: SLIDE_EASE }}
+            >
+              <ParkingDetailPanel
+                lot={selectedLot}
+                userLat={userLat}
+                userLng={userLng}
+                userLocated={userLocated}
+              />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="list"
+              className="absolute inset-0"
+              initial={{ x: '-100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '-100%' }}
+              transition={{ duration: slideDur, ease: SLIDE_EASE }}
+            >
+              <ParkingSidebar
+                parkingLots={parkingLots}
+                selectedLotId={selectedLot?.id ?? null}
+                hoveredLotId={hoveredLotId}
+                onSelect={onSelect}
+                onHover={onHover}
+                userLat={userLat}
+                userLng={userLng}
+                userLocated={userLocated}
+                mapCenter={mapCenter}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
     </aside>
   )
 }

--- a/src/components/DesktopMapPanel.tsx
+++ b/src/components/DesktopMapPanel.tsx
@@ -1,0 +1,96 @@
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect } from 'react'
+import { ParkingDetailPanel } from '@/components/ParkingDetailPanel'
+import { ParkingSidebar } from '@/components/ParkingSidebar'
+import type { ParkingLot } from '@/types/parking'
+
+interface DesktopMapPanelProps {
+  parkingLots: ParkingLot[]
+  selectedLot: ParkingLot | null
+  hoveredLotId: string | null
+  onSelect: (lot: ParkingLot) => void
+  onHover: (id: string | null) => void
+  onCloseDetail: () => void
+  userLat?: number
+  userLng?: number
+  userLocated?: boolean
+  mapCenter?: { lat: number; lng: number } | null
+}
+
+const SLIDE_DURATION = 0.25
+const SLIDE_EASE = [0.16, 1, 0.3, 1] as const
+
+export function DesktopMapPanel({
+  parkingLots,
+  selectedLot,
+  hoveredLotId,
+  onSelect,
+  onHover,
+  onCloseDetail,
+  userLat,
+  userLng,
+  userLocated,
+  mapCenter,
+}: DesktopMapPanelProps) {
+  const reduced = useReducedMotion()
+  const dur = reduced ? 0 : SLIDE_DURATION
+
+  // ESC로 detail에서 list로 pop
+  useEffect(() => {
+    if (!selectedLot) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCloseDetail()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selectedLot, onCloseDetail])
+
+  return (
+    <aside
+      className="relative w-[400px] h-full overflow-hidden rounded-xl shadow-lg border bg-white/95 backdrop-blur-sm pointer-events-auto"
+      aria-label="주차장 패널"
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {selectedLot ? (
+          <motion.div
+            key="detail"
+            className="absolute inset-0"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ duration: dur, ease: SLIDE_EASE }}
+          >
+            <ParkingDetailPanel
+              lot={selectedLot}
+              onClose={onCloseDetail}
+              userLat={userLat}
+              userLng={userLng}
+              userLocated={userLocated}
+            />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="list"
+            className="absolute inset-0"
+            initial={{ x: '-100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '-100%' }}
+            transition={{ duration: dur, ease: SLIDE_EASE }}
+          >
+            <ParkingSidebar
+              parkingLots={parkingLots}
+              selectedLotId={null}
+              hoveredLotId={hoveredLotId}
+              onSelect={onSelect}
+              onHover={onHover}
+              userLat={userLat}
+              userLng={userLng}
+              userLocated={userLocated}
+              mapCenter={mapCenter}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </aside>
+  )
+}

--- a/src/components/ParkingDetailPanel.tsx
+++ b/src/components/ParkingDetailPanel.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import {
+  ChevronLeft,
   ChevronRight,
   Clock,
   CreditCard,
@@ -9,7 +10,6 @@ import {
   Phone,
   Tag,
   ThumbsUp,
-  X,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { NavigationButton } from '@/components/NavigationButton'
@@ -68,20 +68,21 @@ export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
   const sourceCount = tabCounts.reviews + tabCounts.blog + tabCounts.media
 
   return (
-    <div className="w-[400px] shrink-0 flex-col bg-white/95 backdrop-blur-sm rounded-xl shadow-lg border pointer-events-auto flex overflow-hidden animate-in slide-in-from-left-4 duration-150">
+    <div className="w-full h-full flex-col bg-white/95 backdrop-blur-sm flex overflow-hidden">
       <div className="flex-1 overflow-y-auto">
         {/* 헤더 */}
         <section className="relative border-b bg-white px-5 pt-5 pb-4">
           <button
             type="button"
             onClick={onClose}
-            className="absolute right-3 top-3 p-1.5 rounded-md bg-white/90 hover:bg-gray-100 transition-colors cursor-pointer"
-            aria-label="닫기"
+            className="absolute left-3 top-3 inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-gray-100 transition-colors cursor-pointer"
+            aria-label="목록으로 돌아가기"
           >
-            <X className="size-4 text-muted-foreground" />
+            <ChevronLeft className="size-4" />
+            목록
           </button>
 
-          <div className="space-y-4 pr-8">
+          <div className="space-y-4 pt-8">
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-1.5">
                 <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>

--- a/src/components/ParkingDetailPanel.tsx
+++ b/src/components/ParkingDetailPanel.tsx
@@ -1,6 +1,5 @@
 import { Link } from '@tanstack/react-router'
 import {
-  ChevronLeft,
   ChevronRight,
   Clock,
   CreditCard,
@@ -29,13 +28,12 @@ import type { ParkingLot } from '@/types/parking'
 
 interface ParkingDetailPanelProps {
   lot: ParkingLot
-  onClose: () => void
   userLat?: number
   userLng?: number
   userLocated?: boolean
 }
 
-export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
+export function ParkingDetailPanel({ lot }: ParkingDetailPanelProps) {
   const score = lot.difficulty.score
   const reliabilityBadge = getReliabilityBadge(lot.difficulty.reliability)
   const summary = lot.curationReason ?? lot.aiSummary
@@ -71,18 +69,8 @@ export function ParkingDetailPanel({ lot, onClose }: ParkingDetailPanelProps) {
     <div className="w-full h-full flex-col bg-white/95 backdrop-blur-sm flex overflow-hidden">
       <div className="flex-1 overflow-y-auto">
         {/* 헤더 */}
-        <section className="relative border-b bg-white px-5 pt-5 pb-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute left-3 top-3 inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-gray-100 transition-colors cursor-pointer"
-            aria-label="목록으로 돌아가기"
-          >
-            <ChevronLeft className="size-4" />
-            목록
-          </button>
-
-          <div className="space-y-4 pt-8">
+        <section className="border-b bg-white px-5 pt-4 pb-4">
+          <div className="space-y-4">
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-1.5">
                 <Badge variant={lot.pricing.isFree ? 'default' : 'outline'}>

--- a/src/components/ParkingSidebar.tsx
+++ b/src/components/ParkingSidebar.tsx
@@ -87,7 +87,7 @@ export function ParkingSidebar({
   }, [selectedLotId])
 
   return (
-    <aside className="w-[280px] shrink-0 flex-col bg-white/95 backdrop-blur-sm rounded-xl shadow-lg border pointer-events-auto flex overflow-hidden">
+    <aside className="w-full h-full flex-col bg-white/95 backdrop-blur-sm flex overflow-hidden">
       <div className="shrink-0 px-4 py-3 border-b">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/src/components/ParkingSidebar.tsx
+++ b/src/components/ParkingSidebar.tsx
@@ -88,39 +88,30 @@ export function ParkingSidebar({
 
   return (
     <aside className="w-full h-full flex-col bg-white/95 backdrop-blur-sm flex overflow-hidden">
-      <div className="shrink-0 px-4 py-3 border-b">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <ParkingSquare className="size-4 text-blue-500" />
-            <span className="font-semibold text-base">주차장 목록</span>
-          </div>
-          <span className="text-sm text-muted-foreground">{parkingLots.length}개</span>
-        </div>
-        <div className="flex items-center gap-1 mt-2">
-          <ArrowUpDown className="size-3 text-muted-foreground" />
-          <button
-            type="button"
-            onClick={() => setSortMode('distance')}
-            className={`px-2 py-0.5 rounded text-sm cursor-pointer transition-colors ${
-              sortMode === 'distance'
-                ? 'bg-blue-100 text-blue-700 font-medium'
-                : 'text-muted-foreground hover:bg-gray-100'
-            }`}
-          >
-            {userLocated ? '가까운 순' : '지도 중심 순'}
-          </button>
-          <button
-            type="button"
-            onClick={() => setSortMode('difficulty')}
-            className={`px-2 py-0.5 rounded text-xs cursor-pointer transition-colors ${
-              sortMode === 'difficulty'
-                ? 'bg-blue-100 text-blue-700 font-medium'
-                : 'text-muted-foreground hover:bg-gray-100'
-            }`}
-          >
-            쉬운 순
-          </button>
-        </div>
+      <div className="shrink-0 px-4 py-2 border-b flex items-center gap-1">
+        <ArrowUpDown className="size-3 text-muted-foreground" />
+        <button
+          type="button"
+          onClick={() => setSortMode('distance')}
+          className={`px-2 py-0.5 rounded text-sm cursor-pointer transition-colors ${
+            sortMode === 'distance'
+              ? 'bg-blue-100 text-blue-700 font-medium'
+              : 'text-muted-foreground hover:bg-gray-100'
+          }`}
+        >
+          {userLocated ? '가까운 순' : '지도 중심 순'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setSortMode('difficulty')}
+          className={`px-2 py-0.5 rounded text-xs cursor-pointer transition-colors ${
+            sortMode === 'difficulty'
+              ? 'bg-blue-100 text-blue-700 font-medium'
+              : 'text-muted-foreground hover:bg-gray-100'
+          }`}
+        >
+          쉬운 순
+        </button>
       </div>
 
       <div className="flex-1 overflow-y-auto">

--- a/src/components/ParkingSidebar.tsx
+++ b/src/components/ParkingSidebar.tsx
@@ -1,7 +1,7 @@
-import { ArrowUpDown, ChevronRight, MapPin, ParkingSquare } from 'lucide-react'
+import { ChevronRight, MapPin, ParkingSquare } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getDifficultyIcon, getDifficultyLabel, getDistance } from '@/lib/geo-utils'
-import type { ParkingLot, SortMode } from '@/types/parking'
+import type { ParkingLot } from '@/types/parking'
 
 const PAGE_SIZE = 20
 
@@ -37,7 +37,6 @@ export function ParkingSidebar({
   mapCenter,
 }: ParkingSidebarProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
-  const [sortMode, setSortMode] = useState<SortMode>('distance')
 
   // parkingLots 변경 시 표시 개수 초기화
   useEffect(() => {
@@ -48,6 +47,7 @@ export function ParkingSidebar({
   const refLat = userLocated && userLat != null ? userLat : mapCenter?.lat
   const refLng = userLocated && userLng != null ? userLng : mapCenter?.lng
 
+  // 거리순 정렬 (유저/지도 중심 기준). 거리 정보 없으면 난이도 점수로 폴백.
   const sortedLots = useMemo(() => {
     const withDistance = parkingLots.map((lot) => ({
       lot,
@@ -55,19 +55,15 @@ export function ParkingSidebar({
         refLat != null && refLng != null ? getDistance(refLat, refLng, lot.lat, lot.lng) : null,
     }))
 
-    if (sortMode === 'distance') {
-      withDistance.sort((a, b) => {
-        if (a.distance !== null && b.distance !== null) {
-          return a.distance - b.distance
-        }
-        return (b.lot.difficulty.score ?? -1) - (a.lot.difficulty.score ?? -1)
-      })
-    } else {
-      withDistance.sort((a, b) => (b.lot.difficulty.score ?? -1) - (a.lot.difficulty.score ?? -1))
-    }
+    withDistance.sort((a, b) => {
+      if (a.distance !== null && b.distance !== null) {
+        return a.distance - b.distance
+      }
+      return (b.lot.difficulty.score ?? -1) - (a.lot.difficulty.score ?? -1)
+    })
 
     return withDistance
-  }, [parkingLots, refLat, refLng, sortMode])
+  }, [parkingLots, refLat, refLng])
 
   // 선택된 주차장이 visibleCount 밖이면 확장
   const selectedIdx = selectedLotId ? sortedLots.findIndex((s) => s.lot.id === selectedLotId) : -1
@@ -88,32 +84,6 @@ export function ParkingSidebar({
 
   return (
     <aside className="w-full h-full flex-col bg-white/95 backdrop-blur-sm flex overflow-hidden">
-      <div className="shrink-0 px-4 py-2 border-b flex items-center gap-1">
-        <ArrowUpDown className="size-3 text-muted-foreground" />
-        <button
-          type="button"
-          onClick={() => setSortMode('distance')}
-          className={`px-2 py-0.5 rounded text-sm cursor-pointer transition-colors ${
-            sortMode === 'distance'
-              ? 'bg-blue-100 text-blue-700 font-medium'
-              : 'text-muted-foreground hover:bg-gray-100'
-          }`}
-        >
-          {userLocated ? '가까운 순' : '지도 중심 순'}
-        </button>
-        <button
-          type="button"
-          onClick={() => setSortMode('difficulty')}
-          className={`px-2 py-0.5 rounded text-xs cursor-pointer transition-colors ${
-            sortMode === 'difficulty'
-              ? 'bg-blue-100 text-blue-700 font-medium'
-              : 'text-muted-foreground hover:bg-gray-100'
-          }`}
-        >
-          쉬운 순
-        </button>
-      </div>
-
       <div className="flex-1 overflow-y-auto">
         {sortedLots.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm px-4 text-center">

--- a/src/components/ParkingSidebar.tsx
+++ b/src/components/ParkingSidebar.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpDown, MapPin, ParkingSquare } from 'lucide-react'
+import { ArrowUpDown, ChevronRight, MapPin, ParkingSquare } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getDifficultyIcon, getDifficultyLabel, getDistance } from '@/lib/geo-utils'
 import type { ParkingLot, SortMode } from '@/types/parking'
@@ -140,12 +140,13 @@ export function ParkingSidebar({
 
               return (
                 <button
+                  type="button"
                   key={lot.id}
                   ref={(el) => {
                     if (el) itemRefs.current.set(lot.id, el)
                     else itemRefs.current.delete(lot.id)
                   }}
-                  className={`w-full text-left px-4 py-3 border-b border-gray-100 hover:bg-blue-50 transition-colors cursor-pointer ${
+                  className={`w-full text-left px-4 py-3 border-b border-gray-100 hover:bg-blue-50 transition-colors cursor-pointer flex items-center gap-2 ${
                     selected
                       ? 'bg-blue-50 border-l-2 border-l-blue-500'
                       : hovered
@@ -155,50 +156,56 @@ export function ParkingSidebar({
                   onClick={() => onSelect(lot)}
                   onMouseEnter={() => onHover(lot.id)}
                   onMouseLeave={() => onHover(null)}
+                  aria-label={selected ? `${lot.name} 자세히 보기` : `${lot.name} 선택`}
                 >
-                  <div className="flex items-center gap-2 mb-1">
-                    <div
-                      className={`size-2.5 rounded-full shrink-0 ${difficultyColor(lot.difficulty.score)}`}
-                    />
-                    <span className="font-medium text-base truncate flex-1">{lot.name}</span>
-                    <span className="text-sm shrink-0">{icon}</span>
-                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <div
+                        className={`size-2.5 rounded-full shrink-0 ${difficultyColor(lot.difficulty.score)}`}
+                      />
+                      <span className="font-medium text-base truncate flex-1">{lot.name}</span>
+                      <span className="text-sm shrink-0">{icon}</span>
+                    </div>
 
-                  <div className="flex items-center gap-1.5 mb-1.5">
-                    <MapPin className="size-3 text-muted-foreground shrink-0" />
-                    <span className="text-sm text-muted-foreground truncate">{lot.address}</span>
-                  </div>
+                    <div className="flex items-center gap-1.5 mb-1.5">
+                      <MapPin className="size-3 text-muted-foreground shrink-0" />
+                      <span className="text-sm text-muted-foreground truncate">{lot.address}</span>
+                    </div>
 
-                  <div className="flex items-center gap-2 text-sm">
-                    <span
-                      className={`px-1.5 py-0.5 rounded ${
-                        lot.difficulty.score !== null
-                          ? 'bg-gray-100 text-gray-700'
-                          : 'bg-gray-50 text-gray-400'
-                      }`}
-                    >
-                      {label}
-                    </span>
-                    <span
-                      className={`px-1.5 py-0.5 rounded ${
-                        lot.pricing.isFree
-                          ? 'bg-green-50 text-green-700'
-                          : 'bg-gray-100 text-gray-600'
-                      }`}
-                    >
-                      {lot.pricing.isFree ? '무료' : '유료'}
-                    </span>
-                    {lot.totalSpaces > 0 && (
-                      <span className="text-muted-foreground">{lot.totalSpaces}면</span>
-                    )}
-                    {distance !== null && (
-                      <span className="text-muted-foreground ml-auto">
-                        {distance < 1
-                          ? `${Math.round(distance * 1000)}m`
-                          : `${distance.toFixed(1)}km`}
+                    <div className="flex items-center gap-2 text-sm">
+                      <span
+                        className={`px-1.5 py-0.5 rounded ${
+                          lot.difficulty.score !== null
+                            ? 'bg-gray-100 text-gray-700'
+                            : 'bg-gray-50 text-gray-400'
+                        }`}
+                      >
+                        {label}
                       </span>
-                    )}
+                      <span
+                        className={`px-1.5 py-0.5 rounded ${
+                          lot.pricing.isFree
+                            ? 'bg-green-50 text-green-700'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {lot.pricing.isFree ? '무료' : '유료'}
+                      </span>
+                      {lot.totalSpaces > 0 && (
+                        <span className="text-muted-foreground">{lot.totalSpaces}면</span>
+                      )}
+                      {distance !== null && (
+                        <span className="text-muted-foreground ml-auto">
+                          {distance < 1
+                            ? `${Math.round(distance * 1000)}m`
+                            : `${distance.toFixed(1)}km`}
+                        </span>
+                      )}
+                    </div>
                   </div>
+                  {selected && (
+                    <ChevronRight aria-hidden="true" className="size-5 shrink-0 text-blue-500" />
+                  )}
                 </button>
               )
             })}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -54,6 +54,7 @@ function App() {
   const [parkingLots, setParkingLots] = useState<ParkingLot[]>([])
   const [features, setFeatures] = useState<MapFeature[]>([])
   const [selectedLot, setSelectedLot] = useState<ParkingLot | null>(null)
+  const [viewMode, setViewMode] = useState<'list' | 'detail'>('list')
   const [hoveredLotId, setHoveredLotId] = useState<string | null>(null)
   const [moveTo, setMoveTo] = useState<{ lat: number; lng: number } | null>(null)
   const lastViewRef = useRef<{ bounds: MapBounds; zoom: number } | null>(null)
@@ -147,32 +148,57 @@ function App() {
     }
   }, [handleBoundsChanged])
 
-  const handleMarkerClick = useCallback((lot: ParkingLot) => {
-    setSelectedLot(lot)
-  }, [])
+  // 마커/사이드바 클릭: 첫 클릭은 highlight만(데스크톱), 같은 항목 재클릭 시 detail로 push.
+  // 모바일은 ParkingCard가 selectedLot != null이면 자동 노출 (viewMode 무시)이므로 영향 없음.
+  const handleMarkerClick = useCallback(
+    (lot: ParkingLot) => {
+      if (selectedLot?.id === lot.id) {
+        setViewMode('detail')
+      } else {
+        setSelectedLot(lot)
+      }
+    },
+    [selectedLot],
+  )
 
   const handleSearchSelect = useCallback((lot: ParkingLot) => {
+    // 검색은 명시적 의도이므로 detail로 직행
     setMoveTo({ lat: lot.lat, lng: lot.lng })
     setSelectedLot(lot)
+    setViewMode('detail')
   }, [])
 
   const handlePlaceSelect = useCallback((coords: { lat: number; lng: number }) => {
     setSelectedLot(null)
+    setViewMode('list')
     setMoveTo(coords)
   }, [])
 
-  const handleSidebarSelect = useCallback((lot: ParkingLot) => {
-    setMoveTo({ lat: lot.lat, lng: lot.lng })
-    setSelectedLot(lot)
+  const handleSidebarSelect = useCallback(
+    (lot: ParkingLot) => {
+      setMoveTo({ lat: lot.lat, lng: lot.lng })
+      if (selectedLot?.id === lot.id) {
+        setViewMode('detail')
+      } else {
+        setSelectedLot(lot)
+      }
+    },
+    [selectedLot],
+  )
+
+  const handleCloseDetail = useCallback(() => {
+    setViewMode('list')
+    // selectedLot은 유지 → 목록으로 돌아갔을 때 직전 선택 항목 highlight 유지
   }, [])
 
-  // URL ?lotId= 파라미터로 진입 시 지도 이동 + 상세패널 오픈
+  // URL ?lotId= 파라미터로 진입 시: 명시적 진입이므로 detail로 직행
   useEffect(() => {
     if (!mapReady || !lotId) return
     fetchParkingDetail({ data: { id: lotId } })
       .then((lot) => {
         if (!lot) return
         setSelectedLot(lot)
+        setViewMode('detail')
         setMoveTo({ lat: lot.lat, lng: lot.lng })
       })
       .catch((err) => {
@@ -231,10 +257,11 @@ function App() {
           <DesktopMapPanel
             parkingLots={displayedLots}
             selectedLot={selectedLot}
+            viewMode={viewMode}
             hoveredLotId={hoveredLotId}
             onSelect={handleSidebarSelect}
             onHover={setHoveredLotId}
-            onCloseDetail={() => setSelectedLot(null)}
+            onCloseDetail={handleCloseDetail}
             userLat={userLat}
             userLng={userLng}
             userLocated={userLocated}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,7 +19,7 @@ import type { ParkingPoint } from '@/server/parking'
 import { fetchAllParkingPoints, fetchParkingDetail, fetchParkingLots } from '@/server/parking'
 import type { MapBounds, ParkingLot } from '@/types/parking'
 
-const PANEL_WIDTH = 400
+const PANEL_WIDTH = 360
 const FILTER_LEFT = 12 + PANEL_WIDTH + 8
 
 export const Route = createFileRoute('/')({

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { Car } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { NavermapsProvider } from 'react-naver-maps'
 import { toast } from 'sonner'
+import { DesktopMapPanel } from '@/components/DesktopMapPanel'
 import { FloatingFilters } from '@/components/FloatingFilters'
 import { Header } from '@/components/Header'
 import { MapErrorBoundary } from '@/components/MapErrorBoundary'
@@ -10,8 +11,6 @@ import { MapView } from '@/components/MapView'
 import { MobileBottomPanel } from '@/components/MobileBottomPanel'
 import { MobileFilterSheet } from '@/components/MobileFilterSheet'
 import { ParkingCard } from '@/components/ParkingCard'
-import { ParkingDetailPanel } from '@/components/ParkingDetailPanel'
-import { ParkingSidebar } from '@/components/ParkingSidebar'
 import { useGeolocation } from '@/hooks/useGeolocation'
 import { useParkingFilters } from '@/hooks/useParkingFilters'
 import { type MapFeature, useSuperCluster } from '@/hooks/useSuperCluster'
@@ -20,9 +19,8 @@ import type { ParkingPoint } from '@/server/parking'
 import { fetchAllParkingPoints, fetchParkingDetail, fetchParkingLots } from '@/server/parking'
 import type { MapBounds, ParkingLot } from '@/types/parking'
 
-const DETAIL_PANEL_WIDTH = 400
-const FILTER_LEFT_CLOSED = 296
-const FILTER_LEFT_OPENED = 12 + 280 + 8 + DETAIL_PANEL_WIDTH
+const PANEL_WIDTH = 400
+const FILTER_LEFT = 12 + PANEL_WIDTH + 8
 
 export const Route = createFileRoute('/')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -228,34 +226,26 @@ function App() {
           )}
         </div>
 
-        {/* 아일랜드 패널 — 지도 위에 float */}
-        <div className="hidden md:flex absolute top-3 left-3 bottom-3 z-10 gap-2 pointer-events-none">
-          <ParkingSidebar
+        {/* 아일랜드 패널 — 지도 위에 float (List ↔ Detail 슬라이드) */}
+        <div className="hidden md:block absolute top-3 left-3 bottom-3 z-10 pointer-events-none">
+          <DesktopMapPanel
             parkingLots={displayedLots}
-            selectedLotId={selectedLot?.id ?? null}
+            selectedLot={selectedLot}
             hoveredLotId={hoveredLotId}
             onSelect={handleSidebarSelect}
             onHover={setHoveredLotId}
+            onCloseDetail={() => setSelectedLot(null)}
             userLat={userLat}
             userLng={userLng}
             userLocated={userLocated}
             mapCenter={mapCenter}
           />
-          {selectedLot && (
-            <ParkingDetailPanel
-              lot={selectedLot}
-              onClose={() => setSelectedLot(null)}
-              userLat={userLat}
-              userLng={userLng}
-              userLocated={userLocated}
-            />
-          )}
         </div>
 
-        {/* 필터 — 사이드바 오른쪽, 상세패널 열리면 더 오른쪽 */}
+        {/* 필터 — 패널 우측 (단일 위치) */}
         <div
-          className="hidden md:block absolute top-3 z-20 pointer-events-auto transition-[left] duration-200"
-          style={{ left: selectedLot ? `${FILTER_LEFT_OPENED}px` : `${FILTER_LEFT_CLOSED}px` }}
+          className="hidden md:block absolute top-3 z-20 pointer-events-auto"
+          style={{ left: `${FILTER_LEFT}px` }}
         >
           <FloatingFilters
             filters={filters}


### PR DESCRIPTION
## Summary
좌측 island가 차지하던 ~700px(sidebar 280 + detail 400)를 **단일 360px 패널**로 통합. iOS 네비게이션 컨트롤러 스타일의 push/pop 슬라이드로 List ↔ Detail 전환. 사이드바 클릭은 highlight만 (재클릭 또는 chevron으로 디테일 진입). persistent header가 상단에 고정되어 body만 슬라이드.

지도 가시 영역 +340px 확보, iOS 표준 UX 패턴.

## 주요 변경 사항

### 1. 통합 슬라이드 패널 (`a553d0a`)
- 신설 `DesktopMapPanel` — `motion` 라이브러리 `<AnimatePresence>` 사용
- ParkingSidebar / ParkingDetailPanel: 하드코딩 폭 / `animate-in` 클래스 제거
- routes/index.tsx: 단일 DesktopMapPanel로 island 블록 교체

### 2. Highlight-first UX (`4c050fe`)
- 사이드바/마커 첫 클릭 → 해당 항목 highlight + 지도 센터 이동
- 같은 항목 재클릭 → detail로 push 슬라이드
- 선택된 항목 우측에 ChevronRight 아이콘 (시각적 어포던스, 텍스트 없이)
- 헤더 검색 / `?lotId=` deep link는 명시적 의도이므로 detail 직행
- 모바일은 기존 동작 유지 (selectedLot 있으면 ParkingCard 자동 노출)
- 상태: `viewMode: 'list' | 'detail'` 추가 (데스크톱 슬라이드 전용)

### 3. 패널 폭 360px (`0230d80`)
- PANEL_WIDTH 400 → 360, 필터 좌측 오프셋 자동 조정

### 4. 슬라이드 애니메이션 동시 진행 (`d8a39ce`)
- AnimatePresence `mode="wait"` → `"sync"` 변경
- exit/enter가 동시에 진행되어 화면 중앙에서 cross

### 5. Persistent header + body-only slide (`28bddff`)
- 상단 `h-12` persistent header 추가 (슬라이드되지 않음)
- list 모드: `ParkingSquare` + "주차장 목록" + 개수
- detail 모드: ◀ "목록" 뒤로가기 버튼
- 헤더 콘텐츠는 모드 전환 시 cross-fade (150ms)
- ParkingSidebar: 기존 상단 타이틀 라인 제거 (header로 이동)
- ParkingDetailPanel: ◀ 버튼 제거 (header로 이동), `onClose` prop 제거

### 6. 정렬 토글 제거 (`5e95e75`)
- `가까운 순` / `쉬운 순` 토글 UI 삭제
- 항상 거리순 (유저 위치 우선, 없으면 지도 중심 기준), 거리 정보 없으면 난이도 점수 폴백
- 모바일은 별도 컴포넌트라 영향 없음

## 디자인 결정 (확정)
| 항목 | 선택 |
|---|---|
| 슬라이드 방향 | iOS push (Detail 우→중앙, List 중앙→좌) |
| 통합 패널 폭 | 360px |
| 슬라이드 모드 | mode="sync" (동시, cross) |
| 헤더 처리 | persistent header (h-12) + body-only slide |
| 첫 클릭 동작 | highlight + map center |
| 재클릭 동작 | detail push |
| 시각 어포던스 | ChevronRight 아이콘 (텍스트 없이) |
| 검색/deep link | detail 직행 |
| 정렬 | 거리순 고정 (토글 제거) |
| 애니메이션 라이브러리 | motion@12.38.0 |

## Test plan
- [ ] 데스크톱 1024/1440/1920에서 패널이 360px만 차지하고 지도 가시 영역 확보
- [ ] 사이드바 항목 첫 클릭 → highlight + 지도 센터 (디테일 전환 없음)
- [ ] 같은 항목 재클릭 → detail로 슬라이드 push
- [ ] 마커 첫 클릭 → highlight, 같은 마커 재클릭 → detail push
- [ ] 헤더 persistent (슬라이드 시 헤더는 그대로, body만 좌우 이동)
- [ ] 헤더 콘텐츠 cross-fade (list 타이틀 ↔ ◀ 뒤로가기)
- [ ] body 슬라이드 mode="sync" — exit/enter 동시 cross
- [ ] ◀ "목록" 또는 ESC → list로 pop, 직전 항목 highlight 유지
- [ ] Detail 중 다른 마커 클릭 → 슬라이드 없이 콘텐츠 즉시 교체
- [ ] 헤더 검색에서 lot 선택 → detail 직행
- [ ] `?lotId=` deep link 진입 → detail 직행
- [ ] `prefers-reduced-motion: reduce`에서 슬라이드 즉시 전환
- [ ] 모바일 동작 변화 없음 (MobileBottomPanel + ParkingCard)
- [ ] 빌드 통과

## 번들 영향
- `motion@12.38.0` 추가: 클라이언트 번들 ~30~40KB gzipped 증가

🤖 Generated with [Claude Code](https://claude.com/claude-code)