### PR TITLE
🐛 fetchBlogPosts D1 'LIKE pattern too complex' 에러 수정

### DIFF
--- a/src/server/parking.ts
+++ b/src/server/parking.ts
@@ -284,10 +284,12 @@ export const fetchBlogPosts = createServerFn({ method: 'GET' })
         author: schema.webSources.author,
         published_at: schema.webSources.publishedAt,
         relevance_score: schema.webSources.relevanceScore,
+        // INSTR 사용: LIKE의 우변이 컬럼 참조로 동적 구성될 때 D1/SQLite가
+        // "LIKE or GLOB pattern too complex" (SQLITE_ERROR 7500)를 던지는 경우가 있어 회피.
         boost_score: sql<number>`
-          CASE 
-            WHEN ${schema.webSources.title} LIKE '%' || ${schema.parkingLots.name} || '%' THEN 30
-            ELSE 0 
+          CASE
+            WHEN INSTR(${schema.webSources.title}, ${schema.parkingLots.name}) > 0 THEN 30
+            ELSE 0
           END`.as('boost_score'),
       })
       .from(schema.webSources)
@@ -299,9 +301,9 @@ export const fetchBlogPosts = createServerFn({ method: 'GET' })
         ),
       )
       .orderBy(
-        desc(sql`${schema.webSources.relevanceScore} + CASE 
-            WHEN ${schema.webSources.title} LIKE '%' || ${schema.parkingLots.name} || '%' THEN 30
-            ELSE 0 
+        desc(sql`${schema.webSources.relevanceScore} + CASE
+            WHEN INSTR(${schema.webSources.title}, ${schema.parkingLots.name}) > 0 THEN 30
+            ELSE 0
           END`),
         desc(schema.webSources.publishedAt),
       )


### PR DESCRIPTION
## Summary
특정 주차장 wiki 페이지(예: \`/wiki/대산한성필아파트102동앞임시공영주차장-289-2-000093\`) 접근 시 500 에러 발생.

D1에서 직접 쿼리 실행해 원인 확인:
\`\`\`
LIKE or GLOB pattern too complex: SQLITE_ERROR [code: 7500]
\`\`\`

## 원인
\`fetchBlogPosts\`의 boost_score 계산에서 LIKE 우변이 컬럼 참조로 동적 구성됨:
\`\`\`sql
LIKE '%' || parking_lots.name || '%'
\`\`\`

SQLite/D1의 LIKE 옵티마이저는 정적 패턴을 가정하는데, 컬럼 참조로 동적 구성되는 경우 특정 데이터에서 "pattern too complex"로 거부됨. 대부분의 lot에서는 발생 안 하다가 특정 데이터 조합에서 재현됨.

## 해결
\`LIKE\` → \`INSTR()\`로 교체. INSTR은 substring 위치를 반환하는 함수로 같은 substring 매칭을 수행하지만 LIKE 옵티마이저의 복잡도 검사를 거치지 않아 안전함.

\`\`\`sql
-- Before
CASE WHEN web_sources.title LIKE '%' || parking_lots.name || '%' THEN 30 ELSE 0 END
-- After
CASE WHEN INSTR(web_sources.title, parking_lots.name) > 0 THEN 30 ELSE 0 END
\`\`\`

SELECT절과 ORDER BY절에 동일하게 사용된 두 곳 모두 교체.

## 검증
D1 production에서 직접 쿼리:
- LIKE 버전: \`SQLITE_ERROR 7500\` 에러
- INSTR 버전: 정상 결과 (boost_score=30, 같은 값)

## Test plan
- [ ] 배포 후 \`/wiki/대산한성필아파트102동앞임시공영주차장-289-2-000093\` 200 응답 확인
- [ ] 다른 wiki 페이지(기존 정상 동작)도 회귀 없음 확인
- [ ] 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)