### PR TITLE
🔧 robots.txt sitemap URL 수정 (sitemap-main.xml → sitemap.xml)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /admin/
 
-Sitemap: https://easy-parking.xyz/sitemap-main.xml
+Sitemap: https://easy-parking.xyz/sitemap.xml

--- a/src/routes/admin/tools.tsx
+++ b/src/routes/admin/tools.tsx
@@ -86,7 +86,7 @@ function AdminToolsPage() {
 
             <div className="text-xs text-gray-500 space-y-1">
               <p>
-                • <code>/sitemap-main.xml</code> 인덱스 — 모든 주차장 사이트맵 링크
+                • <code>/sitemap.xml</code> 인덱스 — 모든 주차장 사이트맵 링크
               </p>
               <p>
                 • <code>/sitemap-static.xml</code> — 홈, 위키 등 정적 페이지
@@ -138,7 +138,7 @@ function AdminToolsPage() {
 Allow: /
 Disallow: /admin/
 
-Sitemap: https://easy-parking.xyz/sitemap-main.xml`}</pre>
+Sitemap: https://easy-parking.xyz/sitemap.xml`}</pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- `robots.txt` 가 존재하지 않는 `sitemap-main.xml` 을 가리키고 있어 검색엔진의 sitemap discovery 가 실패하던 버그 수정
- 실제 sitemap index 는 `sitemap.xml` (sitemapindex 형식, 하위에 `sitemap-static.xml`, `sitemap-0.xml`, `sitemap-1.xml`)
- `admin/tools.tsx` 의 안내 텍스트도 동일하게 업데이트

## 진단 경위 (issue#124 후속)

\`\`\`
robots.txt:
  Sitemap: https://easy-parking.xyz/sitemap-main.xml   ← 404 ❌

실제 존재:
  https://easy-parking.xyz/sitemap.xml                   ✅
    ├─ sitemap-static.xml  (/, /wiki)
    ├─ sitemap-0.xml        (5,000개)
    └─ sitemap-1.xml        (3,780개)
\`\`\`

GSC URL 검사에서 \`/wiki\` 페이지에 대해 "**감지된 참조 사이트맵이 없습니다**" 메시지가 나온 것이 단서. \`sitemap-handler.ts\` 의 라우트는 \`sitemap.xml\` 만 처리하고 \`sitemap-main.xml\` 은 어디에도 없음 → robots.txt 의 단순 오타.

## Test plan

- [x] `curl -s https://easy-parking.xyz/sitemap-main.xml` → 404
- [x] `curl -s https://easy-parking.xyz/sitemap.xml` → sitemapindex 정상 응답
- [ ] 배포 후 `curl -s https://easy-parking.xyz/robots.txt` → `Sitemap: .../sitemap.xml` 확인
- [ ] GSC → Sitemaps → `sitemap.xml` 다시 처리 (이전 "가져올 수 없음" 상태 해소)
- [ ] 1주 모니터링: GSC 색인 진행률 변동 추적

## 참고

GSC sitemap 제출 현황 (2026-05-03 시점):

| Sitemap | 상태 | 발견 페이지 |
|---|---|---|
| sitemap-static.xml | ✅ 성공 | 2 |
| sitemap-0.xml | ✅ 성공 | 5,000 |
| sitemap-1.xml | ✅ 성공 | 3,780 |
| sitemap.xml | ❌ 가져올 수 없음 | 0 |

→ 8,782 페이지가 이미 발견 상태이지만 색인 거부 중. 본 PR 은 sitemap discovery 개선이 목적이며, 색인 거부의 진짜 원인 (thin/duplicate content) 은 #131 에서 별도 처리.

Related: #124, #131