### PR TITLE
🔍 thin 주차장 페이지 noindex + sitemap-thin 라우트 제거 (#126)

### DIFF
--- a/src/routes/wiki/$slug.tsx
+++ b/src/routes/wiki/$slug.tsx
@@ -51,6 +51,12 @@ export const Route = createFileRoute('/wiki/$slug')({
   head: ({ loaderData }) => {
     const lot = loaderData?.lot
     if (!lot) return {}
+    const tabCounts = loaderData?.tabCounts
+    const isThin =
+      !tabCounts || (tabCounts.blog === 0 && tabCounts.reviews === 0 && tabCounts.media === 0)
+    const robotsContent = isThin
+      ? 'noindex, follow, max-image-preview:large'
+      : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1'
     const slug = makeParkingSlug(lot.name, lot.id)
     const title = `${lot.name} - 주차 난이도/요금/정보 | 쉬운주차장`
     const desc = `${lot.name} (${lot.address}) 주차 난이도 ${getDifficultyLabel(lot.difficulty.score)}, ${lot.pricing.isFree ? '무료' : `기본 ${lot.pricing.baseTime}분 ${lot.pricing.baseFee.toLocaleString()}원`}. 리뷰 ${lot.difficulty.reviewCount}개.`
@@ -92,10 +98,7 @@ export const Route = createFileRoute('/wiki/$slug')({
       meta: [
         { title },
         { name: 'description', content: desc },
-        {
-          name: 'robots',
-          content: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1',
-        },
+        { name: 'robots', content: robotsContent },
         { property: 'og:title', content: title },
         { property: 'og:description', content: desc },
         { property: 'og:type', content: 'article' },

--- a/src/server/sitemap-handler.ts
+++ b/src/server/sitemap-handler.ts
@@ -2,69 +2,71 @@
  * 사이트맵 핸들러 — Worker에서 직접 D1 쿼리하여 XML 응답
  * TanStack Start의 서버 핸들러 문제(Content-Type 덮어쓰기, 동적 라우트 404) 우회
  *
- * sitemap-N.xml      : web_sources 있는 주차장 (메인 인덱스에 포함, 구글 제출)
- * sitemap-thin-N.xml : web_sources 없는 주차장 (인덱스 미포함, 나중에 추가 가능)
+ * sitemap-N.xml : web_sources 있는 주차장 (메인 인덱스에 포함, 구글 제출)
+ *
+ * 참고: web_sources 없는 thin 주차장은 sitemap에서 완전 제외 (#126).
+ *      해당 페이지는 wiki/$slug.tsx에서 noindex 메타로 색인 차단.
  */
 
-const URLS_PER_SITEMAP = 5000;
-const BASE = "https://easy-parking.xyz";
+const URLS_PER_SITEMAP = 5000
+const BASE = 'https://easy-parking.xyz'
 
 function toSlug(name: string): string {
-	return name
-		.trim()
-		.replace(/\s+/g, "-")
-		.replace(/[/\\?#%&=+]/g, "");
+  return name
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[/\\?#%&=+]/g, '')
 }
 
 function makeParkingSlug(name: string, id: string): string {
-	return `${toSlug(name)}-${id}`;
+  return `${toSlug(name)}-${id}`
 }
 
 function xmlResponse(xml: string): Response {
-	return new Response(xml, {
-		headers: {
-			"Content-Type": "application/xml; charset=utf-8",
-			"Cache-Control": "public, max-age=86400",
-		},
-	});
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  })
 }
 
 async function sitemapIndex(db: D1Database): Promise<Response> {
-	// web_sources가 있는 주차장 수만 카운트
-	const result = await db
-		.prepare(
-			`SELECT COUNT(DISTINCT p.id) as count
+  // web_sources가 있는 주차장 수만 카운트
+  const result = await db
+    .prepare(
+      `SELECT COUNT(DISTINCT p.id) as count
        FROM parking_lots p
        INNER JOIN web_sources w ON w.parking_lot_id = p.id`,
-		)
-		.first<{ count: number }>();
-	const totalPages = Math.ceil((result?.count ?? 0) / URLS_PER_SITEMAP);
-	const now = new Date().toISOString().split("T")[0];
+    )
+    .first<{ count: number }>()
+  const totalPages = Math.ceil((result?.count ?? 0) / URLS_PER_SITEMAP)
+  const now = new Date().toISOString().split('T')[0]
 
-	let xml = `<?xml version="1.0" encoding="UTF-8"?>
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>${BASE}/sitemap-static.xml</loc>
     <lastmod>${now}</lastmod>
-  </sitemap>`;
+  </sitemap>`
 
-	for (let i = 0; i < totalPages; i++) {
-		xml += `
+  for (let i = 0; i < totalPages; i++) {
+    xml += `
   <sitemap>
     <loc>${BASE}/sitemap-${i}.xml</loc>
     <lastmod>${now}</lastmod>
-  </sitemap>`;
-	}
+  </sitemap>`
+  }
 
-	xml += `
-</sitemapindex>`;
+  xml += `
+</sitemapindex>`
 
-	return xmlResponse(xml);
+  return xmlResponse(xml)
 }
 
 async function sitemapStatic(): Promise<Response> {
-	const now = new Date().toISOString().split("T")[0];
-	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+  const now = new Date().toISOString().split('T')[0]
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>${BASE}/</loc>
@@ -78,141 +80,87 @@ async function sitemapStatic(): Promise<Response> {
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
-</urlset>`;
+</urlset>`
 
-	return xmlResponse(xml);
+  return xmlResponse(xml)
 }
 
 /** 메인 사이트맵: web_sources 있는 주차장만 */
 async function sitemapPage(db: D1Database, pageId: number): Promise<Response> {
-	const offset = pageId * URLS_PER_SITEMAP;
-	const rows = await db
-		.prepare(
-			`SELECT DISTINCT p.id, p.name
+  const offset = pageId * URLS_PER_SITEMAP
+  const rows = await db
+    .prepare(
+      `SELECT DISTINCT p.id, p.name
        FROM parking_lots p
        INNER JOIN web_sources w ON w.parking_lot_id = p.id
        ORDER BY p.id
        LIMIT ? OFFSET ?`,
-		)
-		.bind(URLS_PER_SITEMAP, offset)
-		.all<{ id: string; name: string }>();
+    )
+    .bind(URLS_PER_SITEMAP, offset)
+    .all<{ id: string; name: string }>()
 
-	if (!rows.results || rows.results.length === 0) {
-		return new Response("Not Found", { status: 404 });
-	}
+  if (!rows.results || rows.results.length === 0) {
+    return new Response('Not Found', { status: 404 })
+  }
 
-	const now = new Date().toISOString().split("T")[0];
-	let xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+  const now = new Date().toISOString().split('T')[0]
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`
 
-	for (const row of rows.results) {
-		const slug = encodeURI(makeParkingSlug(row.name, row.id));
-		xml += `
+  for (const row of rows.results) {
+    const slug = encodeURI(makeParkingSlug(row.name, row.id))
+    xml += `
   <url>
     <loc>${BASE}/wiki/${slug}</loc>
     <lastmod>${now}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
-  </url>`;
-	}
+  </url>`
+  }
 
-	xml += `
-</urlset>`;
+  xml += `
+</urlset>`
 
-	return xmlResponse(xml);
-}
-
-/** 씬 사이트맵: web_sources 없는 주차장 (인덱스 미포함) */
-async function sitemapThinPage(
-	db: D1Database,
-	pageId: number,
-): Promise<Response> {
-	const offset = pageId * URLS_PER_SITEMAP;
-	const rows = await db
-		.prepare(
-			`SELECT p.id, p.name
-       FROM parking_lots p
-       WHERE NOT EXISTS (
-         SELECT 1 FROM web_sources w WHERE w.parking_lot_id = p.id
-       )
-       ORDER BY p.id
-       LIMIT ? OFFSET ?`,
-		)
-		.bind(URLS_PER_SITEMAP, offset)
-		.all<{ id: string; name: string }>();
-
-	if (!rows.results || rows.results.length === 0) {
-		return new Response("Not Found", { status: 404 });
-	}
-
-	const now = new Date().toISOString().split("T")[0];
-	let xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
-
-	for (const row of rows.results) {
-		const slug = encodeURI(makeParkingSlug(row.name, row.id));
-		xml += `
-  <url>
-    <loc>${BASE}/wiki/${slug}</loc>
-    <lastmod>${now}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>`;
-	}
-
-	xml += `
-</urlset>`;
-
-	return xmlResponse(xml);
+  return xmlResponse(xml)
 }
 
 async function sitemapTest(db: D1Database): Promise<Response> {
-	const rows = await db
-		.prepare("SELECT id, name FROM parking_lots ORDER BY id LIMIT 10")
-		.all<{ id: string; name: string }>();
+  const rows = await db
+    .prepare('SELECT id, name FROM parking_lots ORDER BY id LIMIT 10')
+    .all<{ id: string; name: string }>()
 
-	const now = new Date().toISOString().split("T")[0];
-	let xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+  const now = new Date().toISOString().split('T')[0]
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`
 
-	for (const row of rows.results) {
-		const slug = encodeURI(makeParkingSlug(row.name, row.id));
-		xml += `
+  for (const row of rows.results) {
+    const slug = encodeURI(makeParkingSlug(row.name, row.id))
+    xml += `
   <url>
     <loc>${BASE}/wiki/${slug}</loc>
     <lastmod>${now}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
-  </url>`;
-	}
+  </url>`
+  }
 
-	xml += `
-</urlset>`;
+  xml += `
+</urlset>`
 
-	return xmlResponse(xml);
+  return xmlResponse(xml)
 }
 
-export async function handleSitemap(
-	pathname: string,
-	db: D1Database,
-): Promise<Response> {
-	if (pathname === "/sitemap.xml") return sitemapIndex(db);
-	if (pathname === "/sitemap-static.xml") return sitemapStatic();
-	if (pathname === "/sitemap-test.xml") return sitemapTest(db);
+export async function handleSitemap(pathname: string, db: D1Database): Promise<Response> {
+  if (pathname === '/sitemap.xml') return sitemapIndex(db)
+  if (pathname === '/sitemap-static.xml') return sitemapStatic()
+  if (pathname === '/sitemap-test.xml') return sitemapTest(db)
 
-	// /sitemap-0.xml, /sitemap-1.xml, ... (web_sources 있는 것)
-	const mainMatch = pathname.match(/^\/sitemap-(\d+)\.xml$/);
-	if (mainMatch) {
-		const id = parseInt(mainMatch[1], 10);
-		if (id >= 0 && id <= 999) return sitemapPage(db, id);
-	}
+  // /sitemap-0.xml, /sitemap-1.xml, ... (web_sources 있는 것)
+  const mainMatch = pathname.match(/^\/sitemap-(\d+)\.xml$/)
+  if (mainMatch) {
+    const id = parseInt(mainMatch[1], 10)
+    if (id >= 0 && id <= 999) return sitemapPage(db, id)
+  }
 
-	// /sitemap-thin-0.xml, /sitemap-thin-1.xml, ... (web_sources 없는 것, 인덱스 미포함)
-	const thinMatch = pathname.match(/^\/sitemap-thin-(\d+)\.xml$/);
-	if (thinMatch) {
-		const id = parseInt(thinMatch[1], 10);
-		if (id >= 0 && id <= 999) return sitemapThinPage(db, id);
-	}
-
-	return new Response("Not Found", { status: 404 });
+  return new Response('Not Found', { status: 404 })
 }


### PR DESCRIPTION
## Summary

GSC 가 본 도메인의 사이트 평균 품질을 wiki/$slug thin 페이지들로 깎고 있던 문제 수정.

## 변경 사항

### 1) `src/routes/wiki/$slug.tsx`
\`loader\` 의 \`tabCounts\` (이미 SSR 에 fetch 중) 를 활용해 thin 판정:

\`\`\`tsx
const isThin =
  !tabCounts || (tabCounts.blog === 0 && tabCounts.reviews === 0 && tabCounts.media === 0)
const robotsContent = isThin
  ? 'noindex, follow, max-image-preview:large'
  : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1'
\`\`\`

- **추가 쿼리 0회** (loader 의 기존 \`fetchTabCounts\` 결과 재사용)
- thin 정의: blog (web_sources) + reviews + media **모두 0**. 보수적 — reviews/media 만 있어도 색인 가치 있는 콘텐츠로 간주.
- \`follow\` 유지 — thin 페이지에서 다른 페이지로 가는 내부 링크의 권위 전달은 살림.

### 2) `src/server/sitemap-handler.ts`
- \`/sitemap-thin-N.xml\` 라우트 매칭과 \`sitemapThinPage\` 핸들러 완전 삭제
- 이제 직접 호출 시 404 응답
- \`sitemap.xml\` 인덱스에는 원래부터 미포함 상태였으므로 GSC 영향 없음
- 코드/주석 일관성 정리

## 영향 범위

- thin 주차장 (web_sources + reviews + media 모두 0) → \`<meta name="robots" content="noindex, follow">\` 출력
- 그 외 페이지: 기존 \`index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1\` 그대로
- sitemap-0.xml / sitemap-1.xml: 변경 없음 (web_sources 있는 8,782개 그대로)
- robots.txt: 변경 없음 (#132 에서 이미 sitemap.xml 가리키게 fix됨)

## Test plan

- [ ] 배포 후 \`curl -s https://easy-parking.xyz/sitemap-thin-0.xml\` → 404
- [ ] 배포 후 \`curl -s https://easy-parking.xyz/wiki/<thin-slug> | grep robots\` → \`noindex, follow\`
- [ ] 배포 후 \`curl -s https://easy-parking.xyz/wiki/스타필드시티-위례-주차장-KA-1935812519 | grep robots\` → \`index, follow\` (회귀 없음)
- [ ] GSC URL 검사로 thin 페이지 1개 검증 → "noindex 태그가 있어 색인 안 함" 표시
- [ ] 1주~수주 후 GSC Page Indexing 보고서 — "noindex 처리되었지만 색인 생성 요청됨" 카운트 증가, "이상" 카테고리 정리

## 진단 배경

오늘 세션에서 확인된 사항:
- Siteliner: 평균 페이지 크기 **28Kb (7th percentile)**, 단어 수 **556 (27th)**
- 36K 주차장 중 ~27K 가 web_sources 0 (thin)
- thin 페이지가 사이트 평균 품질을 깎아 GSC 의 Helpful Content 신호에 악영향

본 PR 은 thin 페이지를 색인 풀에서 제거. 콘텐츠 보강 (#127) 은 별도.

Closes #126

Related: #124 (closed), #132 (merged), #127 (open, P2)