### PR TITLE
📝 #141 + #148 design + 파이프라인 문서 갱신

### DIFF
--- a/docs/exec-plans/issue-141-ai-summary-regen.md
+++ b/docs/exec-plans/issue-141-ai-summary-regen.md
@@ -1,0 +1,154 @@
+# 구현 계획: web_sources(matched) ai_summary 재생성 (#141)
+
+> Parent: #138 — Phase C
+> Milestone: M9 콘텐츠 보강을 위한 크롤링 파이프라인 개선
+> Depends on: #140 (full_text 22K 보강 완료)
+
+## 요구사항 정리
+
+`web_sources.ai_summary` 22K row 평균 20자 → **full_text 1,400~2,000자 입력으로 재생성하여 평균 200자+ 달성**. 이 ai_summary 가 다운스트림 `parking_lot_stats.ai_summary` 와 wiki SSR 콘텐츠의 입력이 된다.
+
+본 이슈는 raw 단계 (`web_sources_raw.ai_summary`) 는 손대지 않는다 — 필터링 결정은 이미 끝났고, 본 이슈는 SEO/콘텐츠 가치 향상이 목적.
+
+## 현재 상태 파악
+
+### web_sources.ai_summary
+
+- 22,398 row, 평균 20자
+- `match-to-lots.ts:256` 에서 raw.ai_summary 가 그대로 복사됨 → 22K 모두 snippet 기반 빈약 summary
+- 실제 가치: `LIKE` 검색 외 거의 없음 (PR #137 회고)
+
+### web_sources.full_text (#140 완료)
+
+- 16,322 row 가 status='ok' (실제 본문 보유)
+- naver_blog avg 1,980자 / ddg_search avg 1,336자
+- naver_cafe 3,014 row blocked (입력 불가)
+- 차단/실패 5,463 row → ai_summary 재생성 대상 아님 (snippet 그대로 유지)
+
+### 살아있는 가드 (PR #137 도입, 본 이슈에서 그대로 활용)
+
+- `MIN_SUMMARY_LENGTH=200` (`src/server/crawlers/lib/ai-filter.ts:18`)
+- short_summary reject 후처리
+- 보일러플레이트 reject 패턴
+- `scripts/apply-summaries.ts` c안 정책 (new>old AND new≥200)
+
+## 구현 단계
+
+### Phase C-1 — AI summary 생성기 (matched 전용)
+
+**결정 포인트**: 기존 `ai-filter.ts` SYSTEM_PROMPT 를 재사용 vs 새 프롬프트 작성
+
+기존 `ai-filter.ts` 는 raw 단계 분류 + 짧은 summary 가 목적. 본 이슈는 풍부한 summary 가 목적이므로 다른 프롬프트가 더 적합.
+
+신규 함수: `src/server/crawlers/lib/ai-summary-prompt.ts` 에 `MATCHED_SUMMARY_SYSTEM_PROMPT` 추가 (또는 별도 파일).
+
+프롬프트 골격:
+- 입력: full_text (200~50000자) + lot 메타 (name, address)
+- 출력: 200~600자 풍부한 SEO 친화 ai_summary (한국어, 경어체)
+- PR #137 의 "할루시네이션 절대 금지" / "메타 표현 금지" / generic filler 거부 원칙 계승
+- 인용 규율: full_text 에 없는 수치/고유명사 출력 금지
+
+**호출 모드**:
+```ts
+summarizeMatched(input: {
+  full_text: string,
+  lot: { name: string; address: string },
+  source: 'naver_blog' | 'ddg_search'
+}): Promise<{ summary: string; filter_passed: boolean }>
+```
+
+`filter_passed=false` 케이스: 본문이 200자 미만 또는 보일러플레이트로 판정되면 ai_summary 갱신 안 함 (기존 snippet 기반 ai_summary 유지).
+
+### Phase C-2 — 재생성 스크립트
+
+신규: `scripts/regen-matched-summaries.ts`
+
+CLI:
+- `--remote --source=naver_blog|ddg_search|all`
+- `--limit=N` (기본 100)
+- `--concurrency=4` (Anthropic 병렬 호출)
+- `--batch-size=5` (1 API 호출당 row 수, 프롬프트 캐싱 활용)
+- `--shards=N --shard=K` (#140 패턴 재사용)
+- `--output-dir=/tmp/summary-out` (SQL 파일 emit)
+- `--dry-run`
+
+대상 쿼리:
+```sql
+SELECT id, source, parking_lot_id, full_text
+FROM web_sources
+WHERE full_text_status = 'ok'
+  AND LENGTH(full_text) >= 200
+  AND (ai_summary IS NULL OR LENGTH(ai_summary) < 200)
+  AND source IN ('naver_blog','ddg_search')
+LIMIT N
+```
+
+처리 흐름:
+1. 위 쿼리로 대상 row 가져옴
+2. lot 메타 lookup (parking_lots JOIN)
+3. Anthropic Haiku 호출 (배치 5건/호출)
+4. 결과로 SQL UPDATE 생성 (`scripts/fetch-matched-fulltext.ts` 패턴 차용)
+5. SQL 파일 chunk emit → 별도 apply 단계
+
+### Phase C-3 — c안 정책 적용
+
+기존 `scripts/apply-summaries.ts` 를 활용하되 **`web_sources` 대상으로 변형 필요**:
+- 기존 SQL 패턴: `UPDATE web_sources SET ai_summary = '...' WHERE id = N;` — 본 이슈에서도 그대로 매치
+- 신규 옵션: `--target=matched_summary` (단순 라벨링)
+- c안 정책: `new.length >= 200 AND (new > old OR old < 200)` — 그대로
+
+### Phase C-4 — A/B 비교 eval
+
+신규 또는 `scripts/eval-` 패턴 차용: `scripts/eval-matched-summaries.ts`
+
+같은 30~50 row 에 대해:
+- (old) snippet 기반 ai_summary
+- (new) full_text 기반 ai_summary
+
+비교 메트릭:
+- 길이 분포 (avg/p25/p50/p75)
+- generic filler 비율 (휴리스틱: "확인 바랍니다", "정보 제공" 등 패턴)
+- 인용 위반 의심 비율 (full_text 에 없는 한글 명사 N개 이상 등장)
+- 수동 검수용 샘플 10 row 출력 → `eval/matched-summary-v2/report.md`
+
+### Phase C-5 — 단계적 실행
+
+| 단계 | 대상 |
+|---|---|
+| C-1~C-3 구현 + 단위 테스트 | — |
+| Pilot | 100 row 검수 (소스 50/50) |
+| Eval | 30 row A/B → 통과 게이트 |
+| Stage 1 | 1,000 row |
+| Stage 2 | 16,322 row 전체 (full_text=ok) |
+
+## 검증
+
+- web_sources.ai_summary 평균: 20자 → ≥ 250자
+- 빈값 비율: 99% → < 30%
+- Eval pass: filler 비율 < 10%, hallucination 의심 < 5%
+- 다운스트림 (#142 lot summary 재생성) 입력 풍부도 향상
+
+## 비용 추정
+
+- 입력: full_text avg 1,500자 ≈ 1,000 input tokens
+- 출력: 200~400자 summary ≈ 300 output tokens
+- Haiku 4.5: $1/M input + $5/M output → 약 $0.0025/row
+- 16K row × $0.0025 = **~$40**
+- 프롬프트 캐싱 (system prompt) 적용 시 30~50% 절감 가능
+
+## 의존
+
+- `ANTHROPIC_API_KEY` 환경변수 (`.dev.vars`)
+- #140 머지된 main (full_text 컬럼 + 22K 보강 완료)
+- `@anthropic-ai/sdk` (이미 의존성에 있음, `scripts/generate-lot-summary.ts` 사용처 참조)
+
+## 리스크
+
+- **MED** — 인용 규율 후퇴: 길이 압박이 hallucination 유발. anti-padding 가드 + eval 게이트 필수.
+- **MED** — 보일러플레이트 본문 (광고성 블로그) → summary 도 보일러플레이트. PR #137 reject 패턴 계승.
+- **LOW** — Anthropic rate limit: Haiku 빠른 모델, 동시성 4~8 안전.
+- **LOW** — 비용 폭주: $40 예산 내, dry-run 우선.
+
+## 후속 (#142 — Phase D)
+
+`scripts/generate-lot-summary.ts` 재실행. 입력이 풍부해진 web_sources.ai_summary 22K → parking_lot_stats.ai_summary 재생성. 최종 wiki SSR 단어수 / Siteliner 중복율 검증.

--- a/docs/exec-plans/issue-148-filter-relevance-v2.md
+++ b/docs/exec-plans/issue-148-filter-relevance-v2.md
@@ -1,0 +1,177 @@
+# 구현 계획: filter + relevance v2 — full_text 기반 재평가 (#148)
+
+> Parent: #138 — Phase C0 (선행)
+> Milestone: M9 콘텐츠 보강을 위한 크롤링 파이프라인 개선
+> Predecessor: #140 (full_text 22K 보강 완료)
+> Successor: #141 (본 이슈 통과 subset 만 ai_summary 재생성 대상)
+
+## 요구사항 정리
+
+기존 `relevance_score` / 라우 단계 `filter_passed` 는 모두 **snippet 121자** 입력으로 계산됨. #140 으로 16K row 의 full_text 가 확보된 지금, **풀텍스트 기반으로 재평가하여 false positive 를 제거하고 #141 입력 풀을 정제**한다.
+
+본 이슈는 raw 단계는 손대지 않고, matched `web_sources` 만 대상으로 한다.
+
+## 현재 상태 파악
+
+### relevance_score (snippet 기반)
+
+`src/server/crawlers/lib/scoring.ts` `scoreBlogRelevance(title, description, parkingName, address)`:
+- 키워드 매칭 (lot 이름 + 주차 + 지역)
+- noise pattern 차감
+- 0~100 점, 매칭 threshold 기본 60
+- 모든 입력이 snippet (title + description, 둘 다 짧음)
+
+### filter_passed (snippet 기반)
+
+`src/server/crawlers/lib/ai-filter.ts` + `ai-summary-prompt.ts`:
+- raw 단계 SYSTEM_PROMPT 가 snippet content 입력으로 분류
+- `filter_passed`, `removed_by`, `sentiment_score`, `summary` (~21자) 출력
+- match-to-lots 가 raw → web_sources 승격 시 결과 그대로 복사
+
+### 한계
+
+- snippet 만 보고 매칭됐으나 본문은 무관한 false positive 가능 (e.g. "스타필드 위례" 검색 결과에 "위례 카페" 글 매칭)
+- 광고/보일러플레이트가 짧은 snippet 에서는 통과했으나 본문은 99% 광고
+- #141 ai_summary 재생성 시 이런 row 가 입력에 섞이면 hallucination/filler 위험
+
+## 구현 단계
+
+### Phase C0-1 — Schema migration
+
+`migrations/00XX_web_sources_filter_v2.sql`:
+- `web_sources.relevance_score_v2 INTEGER`
+- `web_sources.filter_passed_v2 INTEGER`
+- `web_sources.filter_v2_reason TEXT`
+- `web_sources.filter_v2_evaluated_at TEXT`
+- 인덱스: `idx_ws_filter_v2 ON web_sources(filter_passed_v2, relevance_score_v2)`
+
+기존 `relevance_score` / 라우 분류 결과는 보존. v2 컬럼은 부가 정보. Drizzle schema 동기화.
+
+### Phase C0-2 — relevance v2 algorithm
+
+`src/server/crawlers/lib/scoring.ts` 에 신규:
+
+```ts
+export function scoreBlogRelevanceFull(
+  title: string,
+  fullText: string,
+  parkingName: string,
+  address: string,
+): number
+```
+
+기존 `scoreBlogRelevance` 와 동일 시그너처 (description → fullText). 차이점:
+
+- **본문 길이 정규화**: 본문 길수록 키워드 1회 등장의 가중치 ↓ (밀도 기반)
+- **lot 이름 빈도 가중치**: 1회 vs 3회 vs 10회 등장에 따른 stepwise 보너스
+- **본문 vs 제목 가중치 재조정**: 본문이 풍부하므로 본문 매칭 가중치 ↑
+- **NOISE_PATTERNS** 강화: 풀텍스트 보일러플레이트 패턴 추가
+- 기존 0~100 범위 유지 (downstream 호환)
+
+단위 테스트: `eval-scoring.ts` 패턴 차용 → `eval/scoring-v2/answer-key.json` 신규 30~50 케이스 (snippet vs full_text 동일 row 매핑)
+
+### Phase C0-3 — filter v2 prompt
+
+`src/server/crawlers/lib/ai-summary-prompt.ts` 또는 신규 `ai-filter-v2-prompt.ts` 에 `FILTER_V2_SYSTEM_PROMPT`:
+
+- 입력: full_text + lot meta (name, address)
+- 출력 JSON: `{ filter_passed, removed_by, sentiment_score, ai_difficulty_keywords }`
+- **summary 출력 안 함** (별도 #141 에서 처리, 책임 분리)
+- 판정 강화:
+  - 본문 200자 미만 → filter_passed=false
+  - lot 이름 등장 0회 → filter_passed=false (본문이 다른 주차장 얘기)
+  - 광고/협찬 명시 ("쿠팡 파트너스", "체험단" 등) → filter_passed=false
+  - SEO 보일러플레이트 패턴 ("Top5 저렴한 주변 주차장 정리") → filter_passed=false
+  - "운영 시간을 확인하시기 바랍니다" 류 generic safety filler 만 → filter_passed=false
+
+PR #137 reject 패턴 그대로 계승.
+
+### Phase C0-4 — Re-run script
+
+신규: `scripts/refilter-matched.ts` (#140 패턴 차용)
+
+CLI:
+- `--remote --source=naver_blog|ddg_search|all`
+- `--limit=N --concurrency=4 --batch-size=10`
+- `--shards=N --shard=K` (모듈로 분할)
+- `--output-dir=/tmp/refilter-out`
+- `--dry-run`
+
+대상 쿼리:
+```sql
+SELECT id, source, parking_lot_id, title, full_text
+FROM web_sources
+WHERE full_text_status = 'ok'
+  AND LENGTH(full_text) >= 200
+  AND filter_passed_v2 IS NULL
+  AND source IN ('naver_blog','ddg_search')
+  ${shardClause}
+LIMIT N
+```
+
+처리:
+1. lot 메타 lookup (parking_lots JOIN)
+2. **로컬**: `scoreBlogRelevanceFull()` 호출 → relevance_score_v2 계산 (AI 호출 없음, 무료)
+3. **AI**: Anthropic Haiku 배치 10건/호출 → filter_passed_v2 + sentiment + reason
+4. SQL UPDATE 생성 → chunk emit (1000 row/file)
+5. `wrangler d1 execute --file` 일괄 적용
+
+### Phase C0-5 — A/B eval
+
+신규: `scripts/eval-filter-v2.ts`
+
+같은 30~50 row 에 대해:
+- (v1) 기존 relevance_score, raw 단계 filter_passed
+- (v2) full_text 기반 재평가
+
+비교 메트릭:
+- relevance: avg/p25/p50 분포 변화
+- filter_passed flip 카운트 (v1=1 → v2=0 = false positive 발견; v1=0 → v2=1 = 미주류)
+  - 기대: 1→0 ≤ 25% (false positive 정밀도 향상), 0→1 ≤ 5% (raw 단계도 이미 잘 거름)
+- 수동 검수 샘플 10 row → `eval/filter-v2/report.md`
+- hallucination 의심 0건
+
+### Phase C0-6 — 단계적 실행
+
+| 단계 | 대상 | 게이트 |
+|---|---|---|
+| C0-1~C0-4 구현 + 단위 테스트 | — | scoring v2 회귀 통과 |
+| Pilot | 100 row (소스 50/50 mixed) | 수동 검수 OK |
+| Eval | 30 row v1 vs v2 비교 | flip 분포 합리적 |
+| Stage 1 | 1,000 row | over-rejection 없음 |
+| Stage 2 | 16,322 row 전체 | — |
+
+## 검증
+
+- v2 평가 16K 완료
+- 정밀도 향상: 수동 검수 false positive ≥ 50% 감소
+- #141 입력 풀 결정 기준: `filter_passed_v2 = 1 AND relevance_score_v2 >= THRESHOLD`
+- 다운스트림: #141 가 정제된 ~12K row 입력으로 ai_summary 재생성
+
+## 비용
+
+- relevance v2: 로컬, 무료
+- filter v2: Haiku batch 10건/호출, 16K row × ~$0.0015 = **~$25**
+
+## 의존
+
+- `ANTHROPIC_API_KEY` (`.dev.vars`)
+- #140 머지된 main (full_text + 22K 보강)
+- bun 런타임
+
+## 리스크
+
+- **MED** — over-filtering: v2 가 너무 엄격하면 진짜 가치 있는 row 도 reject. → eval 게이트 + 보수적 threshold + 수동 검수 의무.
+- **MED** — relevance threshold 결정: 기존 60 점 기준. v2 분포가 다르면 재조정 필요. eval 결과 보고 결정.
+- **LOW** — Anthropic rate limit: Haiku 빠른 모델, 동시성 4~8 안전.
+
+## 후속
+
+- #141: v2 통과 subset 만 ai_summary 재생성
+- #142: lot summary 재생성 시 v2 필터링된 web_sources 만 사용
+
+## 관련 파일
+
+- 기존: `src/server/crawlers/lib/scoring.ts`, `src/server/crawlers/lib/ai-filter.ts`, `src/server/crawlers/lib/ai-summary-prompt.ts`
+- 신규: `migrations/00XX_web_sources_filter_v2.sql`, `scripts/refilter-matched.ts`, `scripts/eval-filter-v2.ts`
+- 변경: `src/db/schema.ts` (4 컬럼 추가)

--- a/docs/references/poi-pipeline-v2.md
+++ b/docs/references/poi-pipeline-v2.md
@@ -171,6 +171,8 @@ Bayesian 통합: structural_prior(3.0) 기반, n_effective로 신뢰도 산출.
 [매칭]     → web_sources INSERT (raw_source_id FK, ai_summary 복사)
               ↓ (외부 batch — #140)
 [풀텍스트] → web_sources.full_text (1,400~2,000자, ok rows)
+              ↓ (#148 — 예정)
+[재필터]   → filter_passed_v2 / relevance_score_v2 (full_text 입력 재평가)
               ↓ (#141 — 예정)
 [재요약]   → web_sources.ai_summary 재생성 (full_text 입력, 200자+)
               ↓ (최근 매칭 주차장)

--- a/docs/references/poi-pipeline-v2.md
+++ b/docs/references/poi-pipeline-v2.md
@@ -1,6 +1,6 @@
 # 크롤링 파이프라인 v2 — 현행 아키텍처
 
-> 최초 작성: 2026-03-13 | 현행화: 2026-04-02
+> 최초 작성: 2026-03-13 | 현행화: 2026-05-03 (#140 풀텍스트 보강 단계 추가)
 
 ## 목적
 
@@ -10,13 +10,14 @@
 ## 2-테이블 구조
 
 ```
-web_sources_raw (원본 + 필터링)
+web_sources_raw (원본 + 필터링, content = snippet 121자)
   ↓ AI 필터 통과 + 주차장 매칭 완료
-web_sources (검증된 데이터만)
+web_sources (검증된 데이터만, full_text 1,400~2,000자 — #140 이후)
 ```
 
-- **`web_sources_raw`**: 크롤링 원본 저장. `filter_passed`, `matched_at` 등 파이프라인 상태 관리
-- **`web_sources`**: 필터 + 매칭 통과분만 존재. `is_ad`, `filter_passed` 컬럼 없음 (2026-04-02 제거)
+- **`web_sources_raw`**: 크롤링 원본 저장. `filter_passed`, `matched_at` 등 파이프라인 상태 관리. `content` = Naver/DDG 검색 API 의 `description` 스니펫 (~120자).
+- **`web_sources`**: 필터 + 매칭 통과분. `full_text` (#140 풀텍스트 fetcher 로 보강), `full_text_status` (pending/ok/blocked/not_found/too_short/timeout/error), `full_text_fetched_at` 컬럼 보유.
+- **풀텍스트 보강 (#140, 2026-05-03)**: matched 22K row 의 `full_text` 를 batch fetch로 채움. naver_blog 9,078 ok (avg 1,980자), ddg_search 7,244 ok (avg 1,336자), naver_cafe 3,014 blocked:spa_shell. 신규 매칭 row 는 자동 `pending` 으로 큐잉, 주기적 batch 가 픽업.
 
 ---
 
@@ -52,6 +53,18 @@ web_sources (검증된 데이터만)
 │                                                   │
 │  DDG 크롤링 (duckduckgo-search.ts)                │
 │  └ subrequest 한도 분리 위해 별도 cron              │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ 외부 (수동/cron host) — #140 추가                  │
+│                                                   │
+│  5. 풀텍스트 보강 (fetch-matched-fulltext.ts)      │
+│     └ web_sources WHERE full_text_status='pending' │
+│       → fetchFullText() 호출 (naver_blog/cafe/ddg) │
+│       → 결과를 SQL 파일로 emit (1000건/file)        │
+│       → wrangler d1 execute --file 로 일괄 적용     │
+│                                                   │
+│  Worker 비호환 (jsdom/readability) → Cron 외부 실행 │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -108,6 +121,30 @@ raw 소스 1건
 - `web_sources` INSERT 시 `raw_source_id`로 원본 연결
 - 1 source → N 주차장 관계 지원 (source_id에 lot_id 접미사)
 
+### 4.5. 풀텍스트 보강 (#140, 외부 batch)
+
+**파일**: `scripts/fetch-matched-fulltext.ts` + `src/server/crawlers/lib/full-text-fetcher.ts`
+
+기존 `web_sources_raw.content` 와 그로부터 복사된 `web_sources.content` 는 검색 API의 description 스니펫 (~120자) — AI 필터/요약/SEO에 부족한 길이. 본 단계에서 **matched row 의 source_url을 다시 fetch 해 본문 풀텍스트를 `web_sources.full_text` 에 저장**.
+
+| source | 추출기 | 평균 본문 | 성공률 (public) |
+|---|---|---:|---:|
+| naver_blog | iframe → `.se-main-container` / `.post-view` / `#postViewArea` (cheerio) | 1,980자 | 96.7% |
+| naver_cafe | SPA 전환됨 → `blocked:spa_shell` 분류 | n/a | 0% |
+| ddg_search | jsdom + Mozilla Readability + cheerio fallback | 1,336자 | 83.4% |
+
+가드:
+- `MIN_TEXT_LENGTH=200` 미만 → `too_short`
+- PDF / binary 응답 (`%PDF-`, `%%EOF`) → `error:binary_document`
+- 단일 UPDATE > 50KB → `error` (D1 SQLITE_TOOBIG 회피)
+
+운영:
+- 신규 매칭 row 는 자동 `full_text_status='pending'` (스키마 default)
+- 주기적으로 외부 host 또는 수동으로 batch 실행
+- 멀티-shard 병렬화: `--shards=N --shard=K` (모듈로 분할)
+
+문서: `docs/exec-plans/issue-140-fulltext-batch.md`, `data/fulltext-batch-report.md`
+
 ### 4. 스코어링 재계산
 
 **파일**: `src/server/crawlers/lib/scoring-engine.ts`
@@ -127,11 +164,15 @@ Bayesian 통합: structural_prior(3.0) 기반, n_effective로 신뢰도 산출.
 ## 데이터 흐름 요약
 
 ```
-[크롤러] → web_sources_raw (INSERT OR IGNORE)
+[크롤러]   → web_sources_raw  (snippet 121자, INSERT OR IGNORE)
               ↓
-[AI 필터] → filter_passed=1/0, sentiment_score 등 업데이트
+[AI 필터]  → filter_passed=1/0, sentiment_score, ai_summary(~21자) 업데이트
               ↓ (filter_passed=1 & matched_at IS NULL)
-[매칭]   → web_sources INSERT (검증된 데이터만)
+[매칭]     → web_sources INSERT (raw_source_id FK, ai_summary 복사)
+              ↓ (외부 batch — #140)
+[풀텍스트] → web_sources.full_text (1,400~2,000자, ok rows)
+              ↓ (#141 — 예정)
+[재요약]   → web_sources.ai_summary 재생성 (full_text 입력, 200자+)
               ↓ (최근 매칭 주차장)
 [스코어링] → parking_lot_stats UPSERT
 ```
@@ -149,10 +190,13 @@ Bayesian 통합: structural_prior(3.0) 기반, n_effective로 신뢰도 산출.
 | `src/server/crawlers/duckduckgo-search.ts` | DDG 크롤러 (별도 cron) |
 | `src/server/crawlers/ai-filter-batch.ts` | AI 필터 배치 |
 | `src/server/crawlers/lib/ai-filter.ts` | AI 필터 모듈 (Haiku 프롬프트) |
+| `src/server/crawlers/lib/full-text-fetcher.ts` | **#139** 풀텍스트 fetcher (naver_blog/cafe/ddg) |
 | `src/server/crawlers/match-to-lots.ts` | 주차장 하이브리드 매칭 |
 | `src/server/crawlers/lib/scoring.ts` | 관련도 채점 + 신뢰도 판정 |
 | `src/server/crawlers/lib/scoring-engine.ts` | 통합 스코어링 엔진 |
 | `src/server/crawlers/lib/sentiment.ts` | 감성 분석 (룰 기반) |
+| `scripts/fetch-matched-fulltext.ts` | **#140** 풀텍스트 batch (외부 실행) |
+| `scripts/clean-pdf-updates.ts` | #140 1회용 PDF UPDATE cleaner |
 | `scripts/compute-parking-stats.ts` | 전체 배치 스코어링 재계산 |
 
 ---

--- a/docs/references/web-sources-ai-summary.md
+++ b/docs/references/web-sources-ai-summary.md
@@ -3,6 +3,17 @@
 > **갱신 이력**
 > - 2026-04: v1 (30~60자 한줄, 단순 한줄 재생성)
 > - 2026-05: v2 (200~600자 long-form, lot당 top-N 후보군, lot-specific) — 이슈 #135
+> - 2026-05: v3 (#140 풀텍스트 보강 → web_sources.full_text 1,400~2,000자 입력) — 이슈 #141 진행 중
+
+## v2 한계 + v3 방향성
+
+v2 의 본질적 한계: 입력으로 받는 `web_sources.content` 가 121자 snippet (Naver/DDG 검색 API description). 200~600자 long-form 을 합성적으로 만들면 hallucination 위험. PR #137 회고에서 6.7% 수율 (45→3) 확인.
+
+v3 (#140 + #141) 가 해결하는 것:
+- **#140**: `web_sources.full_text` 컬럼 도입. matched 22K row 의 source_url 을 다시 fetch 해 본문 풀텍스트 (avg 1,400~2,000자) 저장.
+- **#141**: ai_summary 재생성 시 `full_text` 를 입력으로 사용 → 진짜 long-form 가능, hallucination 위험 대폭 축소.
+
+본 문서의 v2 절차는 여전히 유효하지만 입력 컬럼이 `content` → `full_text` 로 이동한다. v3 변경은 #141 완료 후 갱신 예정.
 
 ## 배경
 


### PR DESCRIPTION
## Summary

#141 (Phase C — ai_summary 재생성) 착수 전 design 문서 정리.

## 변경

- **poi-pipeline-v2.md**:
  - 2-테이블 구조에 `full_text` 컬럼 + #140 결과 명시 (naver_blog 1,980자 / ddg 1,336자)
  - Cron 흐름도에 5단계 (풀텍스트 보강 — 외부 batch) 추가
  - 데이터 흐름 요약에 풀텍스트/재요약 노드 추가
  - 관련 파일 표에 `full-text-fetcher.ts` / `fetch-matched-fulltext.ts` / `clean-pdf-updates.ts` 추가
- **web-sources-ai-summary.md**:
  - v2 한계 (snippet 121자 입력 → hallucination 위험) 솔직하게 정리
  - v3 방향 (#140 full_text 1,400~2,000자 입력 전환) 갱신 이력 추가
- **issue-141-ai-summary-regen.md** (신규):
  - C-1: matched 전용 summarizer 함수 + 새 시스템 프롬프트
  - C-2: `regen-matched-summaries.ts` (#140 패턴 차용, 샤딩/SQL emit)
  - C-3: c안 정책 (`apply-summaries.ts` 활용)
  - C-4: A/B eval (snippet vs full_text 비교)
  - C-5: 단계 실행 (100 → 1K → 16K)
  - 비용 ~$40 추정

## 다음

PR 머지 후 #141 C-1 구현 착수.

## Test plan
- [x] 문서 변경만, 코드 영향 없음