### PR TITLE
📝 #138 Phase 라벨 정리 (C0/C/D → C/D/E)

### DIFF
--- a/docs/exec-plans/issue-141-ai-summary-regen.md
+++ b/docs/exec-plans/issue-141-ai-summary-regen.md
@@ -1,8 +1,8 @@
-# 구현 계획: web_sources(matched) ai_summary 재생성 (#141)
+# 구현 계획: web_sources(matched) ai_summary 재생성 (#141 — Phase D)
 
-> Parent: #138 — Phase C
+> Parent: #138 — Phase D
 > Milestone: M9 콘텐츠 보강을 위한 크롤링 파이프라인 개선
-> Depends on: #140 (full_text 22K 보강 완료)
+> Depends on: #140 (full_text 보강 완료), #148 (filter + relevance v2 통과 subset)
 
 ## 요구사항 정리
 
@@ -34,7 +34,7 @@
 
 ## 구현 단계
 
-### Phase C-1 — AI summary 생성기 (matched 전용)
+### Phase D-1 — AI summary 생성기 (matched 전용)
 
 **결정 포인트**: 기존 `ai-filter.ts` SYSTEM_PROMPT 를 재사용 vs 새 프롬프트 작성
 
@@ -59,7 +59,7 @@ summarizeMatched(input: {
 
 `filter_passed=false` 케이스: 본문이 200자 미만 또는 보일러플레이트로 판정되면 ai_summary 갱신 안 함 (기존 snippet 기반 ai_summary 유지).
 
-### Phase C-2 — 재생성 스크립트
+### Phase D-2 — 재생성 스크립트
 
 신규: `scripts/regen-matched-summaries.ts`
 
@@ -90,14 +90,14 @@ LIMIT N
 4. 결과로 SQL UPDATE 생성 (`scripts/fetch-matched-fulltext.ts` 패턴 차용)
 5. SQL 파일 chunk emit → 별도 apply 단계
 
-### Phase C-3 — c안 정책 적용
+### Phase D-3 — c안 정책 적용
 
 기존 `scripts/apply-summaries.ts` 를 활용하되 **`web_sources` 대상으로 변형 필요**:
 - 기존 SQL 패턴: `UPDATE web_sources SET ai_summary = '...' WHERE id = N;` — 본 이슈에서도 그대로 매치
 - 신규 옵션: `--target=matched_summary` (단순 라벨링)
 - c안 정책: `new.length >= 200 AND (new > old OR old < 200)` — 그대로
 
-### Phase C-4 — A/B 비교 eval
+### Phase D-4 — A/B 비교 eval
 
 신규 또는 `scripts/eval-` 패턴 차용: `scripts/eval-matched-summaries.ts`
 
@@ -111,7 +111,7 @@ LIMIT N
 - 인용 위반 의심 비율 (full_text 에 없는 한글 명사 N개 이상 등장)
 - 수동 검수용 샘플 10 row 출력 → `eval/matched-summary-v2/report.md`
 
-### Phase C-5 — 단계적 실행
+### Phase D-5 — 단계적 실행
 
 | 단계 | 대상 |
 |---|---|

--- a/docs/exec-plans/issue-148-filter-relevance-v2.md
+++ b/docs/exec-plans/issue-148-filter-relevance-v2.md
@@ -1,6 +1,6 @@
-# 구현 계획: filter + relevance v2 — full_text 기반 재평가 (#148)
+# 구현 계획: filter + relevance v2 — full_text 기반 재평가 (#148 — Phase C)
 
-> Parent: #138 — Phase C0 (선행)
+> Parent: #138 — Phase C (선행, #141 직전)
 > Milestone: M9 콘텐츠 보강을 위한 크롤링 파이프라인 개선
 > Predecessor: #140 (full_text 22K 보강 완료)
 > Successor: #141 (본 이슈 통과 subset 만 ai_summary 재생성 대상)
@@ -36,7 +36,7 @@
 
 ## 구현 단계
 
-### Phase C0-1 — Schema migration
+### Phase C-1 — Schema migration
 
 `migrations/00XX_web_sources_filter_v2.sql`:
 - `web_sources.relevance_score_v2 INTEGER`
@@ -47,7 +47,7 @@
 
 기존 `relevance_score` / 라우 분류 결과는 보존. v2 컬럼은 부가 정보. Drizzle schema 동기화.
 
-### Phase C0-2 — relevance v2 algorithm
+### Phase C-2 — relevance v2 algorithm
 
 `src/server/crawlers/lib/scoring.ts` 에 신규:
 
@@ -70,7 +70,7 @@ export function scoreBlogRelevanceFull(
 
 단위 테스트: `eval-scoring.ts` 패턴 차용 → `eval/scoring-v2/answer-key.json` 신규 30~50 케이스 (snippet vs full_text 동일 row 매핑)
 
-### Phase C0-3 — filter v2 prompt
+### Phase C-3 — filter v2 prompt
 
 `src/server/crawlers/lib/ai-summary-prompt.ts` 또는 신규 `ai-filter-v2-prompt.ts` 에 `FILTER_V2_SYSTEM_PROMPT`:
 
@@ -86,7 +86,7 @@ export function scoreBlogRelevanceFull(
 
 PR #137 reject 패턴 그대로 계승.
 
-### Phase C0-4 — Re-run script
+### Phase C-4 — Re-run script
 
 신규: `scripts/refilter-matched.ts` (#140 패턴 차용)
 
@@ -116,7 +116,7 @@ LIMIT N
 4. SQL UPDATE 생성 → chunk emit (1000 row/file)
 5. `wrangler d1 execute --file` 일괄 적용
 
-### Phase C0-5 — A/B eval
+### Phase C-5 — A/B eval
 
 신규: `scripts/eval-filter-v2.ts`
 
@@ -131,7 +131,7 @@ LIMIT N
 - 수동 검수 샘플 10 row → `eval/filter-v2/report.md`
 - hallucination 의심 0건
 
-### Phase C0-6 — 단계적 실행
+### Phase C-6 — 단계적 실행
 
 | 단계 | 대상 | 게이트 |
 |---|---|---|


### PR DESCRIPTION
## Summary

워크플로우 순서대로 sub-issue Phase 라벨 정리. \`C0\` 라는 어색한 라벨 제거.

| 새 | 이전 | issue | 작업 |
|---|---|---|---|
| Phase A | A | #139 | full-text fetcher (완료) |
| Phase B | B | #140 | full_text 22K 보강 (완료) |
| **Phase C** | C0 | **#148** | **filter + relevance v2** |
| **Phase D** | C | **#141** | ai_summary 재생성 |
| **Phase E** | D | **#142** | lot summary + 검증 |

## 변경 범위

- 디자인 문서 2개 (\`issue-141-ai-summary-regen.md\`, \`issue-148-filter-relevance-v2.md\`)
- #138/#141/#142/#148 GitHub 이슈 title + body (PR 외 GitHub UI 에서 직접 수정)

## Test plan

- [x] 디자인 문서 변경만, 코드 영향 없음